### PR TITLE
Remove references to removed code coverage from readme/PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,6 @@
 
 #### Pull request checklist
 
-- [ ] Addresses an existing issue: Fixes #0000
-- [ ] Added relevant unit test for your changes. (`yarn test`)
-- [ ] Verified code coverage for the changes made.
+- [ ] If this PR addresses an existing issue, it is linked: Fixes #0000
+- [ ] `yarn test` passes in all affected samples
+- [ ] Added any applicable tests

--- a/typescript-selenium-webdriver/README.md
+++ b/typescript-selenium-webdriver/README.md
@@ -1,7 +1,6 @@
 # typescript-selenium-webdriver sample
 
 [![Build Status](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_apis/build/status/typescript-selenium-webdriver%20CI?branchName=master)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/latest?definitionId=25&branchName=master)
-[![Code coverage](https://img.shields.io/azure-devops/coverage/accessibility-insights/axe-pipelines-samples/25.svg)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/latest?definitionId=25&branchName=master)
 
 This sample demonstrates how you might set up a CI build for a simple html page to perform end to end browser accessibility tests, including how to suppress known failures using a baseline file.
 


### PR DESCRIPTION
#### Description of changes

An earlier PR removed code coverage build tasks (they are irrelevant to the sample, since the sample has no non-test js/ts code). This updates readme and PR template to match.

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: Fixes #0000
- [x] `yarn test` passes in all affected samples
- [x] Added any applicable tests
