### PR TITLE
use jest-circus runner to improve beforeAll/beforeEach failure behavior

### DIFF
--- a/typescript-selenium-webdriver/jest.config.js
+++ b/typescript-selenium-webdriver/jest.config.js
@@ -1,8 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 module.exports = {
+    // These are necessary to use typescript with Jest tests
     preset:'ts-jest',
     testEnvironment: 'node',
+
+    // Using the jest-circus testRunner ensures that tests will not run if beforeAll or beforeEach fails.
+    //
+    // Since browser automation tests commonly use beforeAll/beforeEach to perform browser/page setup,
+    // it's usually misleading to allow tests to continue trying to execute when they have failed.
+    //
+    // See https://github.com/facebook/jest/issues/2713 for details.
+    testRunner: 'jest-circus/runner',
+
     reporters: [
         // This enables console output for local development and build log output in Pipelines.
         'default',

--- a/typescript-selenium-webdriver/package.json
+++ b/typescript-selenium-webdriver/package.json
@@ -12,6 +12,7 @@
         "axe-webdriverjs": "^2.2.0",
         "http-server": "^0.11.1",
         "jest": "^24.8.0",
+        "jest-circus": "^24.8.0",
         "jest-junit": "^6.4.0",
         "selenium-webdriver": "^4.0.0-alpha.1",
         "ts-jest": "^24.0.2",

--- a/typescript-selenium-webdriver/tests/index.test.ts
+++ b/typescript-selenium-webdriver/tests/index.test.ts
@@ -8,15 +8,15 @@ import { Builder, By, ThenableWebDriver, until } from 'selenium-webdriver';
 import * as chrome from 'selenium-webdriver/chrome';
 import { promisify } from 'util';
 
+// The default timeout for tests/fixtures (5 seconds) is not always enough to start/quit/navigate a browser instance.
+const TEST_TIMEOUT_MS = 30000;
+
 describe('index.html', () => {
     let driver: ThenableWebDriver;
 
     // Starting a browser instance is time-consuming, so we share one browser instance between
     // all tests in the file (by initializing it in beforeAll rather than beforeEach)
     beforeAll(async () => {
-        // The default timeout (5 seconds) is not always enough to start/quit a browser instance
-        jest.setTimeout(30000);
-
         // This is for the benefit of the Azure Pipelines Hosted Windows agents, which come with
         // webdrivers preinstalled but not on the PATH where Selenium looks for them by default.
         // See https://docs.microsoft.com/en-us/azure/devops/pipelines/test/continuous-test-selenium#decide-how-you-will-deploy-and-test-your-app
@@ -32,11 +32,11 @@ describe('index.html', () => {
             .forBrowser('chrome')
             .setChromeOptions(new chrome.Options().headless())
             .build();
-    });
+    }, TEST_TIMEOUT_MS);
 
     afterAll(async () => {
         await driver.quit();
-    });
+    }, TEST_TIMEOUT_MS);
 
     beforeEach(async () => {
         // For simplicity, we're pointing our test browser directly to a static html file on disk.
@@ -47,7 +47,7 @@ describe('index.html', () => {
         // See https://jestjs.io/docs/en/testing-frameworks for examples.
         const pageUnderTest = 'file://' + path.join(__dirname, '..', 'src', 'index.html');
         await driver.get(pageUnderTest);
-    });
+    }, TEST_TIMEOUT_MS);
 
     it('renders the expected header text', async () => {
         const header = await driver.wait(until.elementLocated(By.css('h1')));
@@ -55,7 +55,7 @@ describe('index.html', () => {
         const headerText = await header.getText();
 
         expect(headerText).toEqual('This is a static sample page with some accessibility issues');
-    });
+    }, TEST_TIMEOUT_MS);
 
     it('only contains known accessibility violations', async () => {
         // Ensure that the page is loaded and rendered
@@ -79,5 +79,5 @@ describe('index.html', () => {
             // it's a good idea to use a spacing argument (here, "2") to pretty-print the
             // JSON. This makes it much more pleasant to diff when it changes. 
             JSON.stringify(sarifResults, null, 2));
-    });
+    }, TEST_TIMEOUT_MS);
 });

--- a/typescript-selenium-webdriver/yarn.lock
+++ b/typescript-selenium-webdriver/yarn.lock
@@ -1762,6 +1762,28 @@ jest-changed-files@^24.8.0:
     execa "^1.0.0"
     throat "^4.0.0"
 
+jest-circus@^24.8.0:
+  version "24.8.0"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-24.8.0.tgz#24ef638ac178fdf614a0d464e708d2b6e6900979"
+  integrity sha512-2QASG3QuDdk0SMP2O73D8u3/lc/A/E2G7q23v5WhbUR+hCGzWZXwRMKif18f11dSLfL1wcrMbwE4IorvV0DRVw==
+  dependencies:
+    "@babel/traverse" "^7.1.0"
+    "@jest/environment" "^24.8.0"
+    "@jest/test-result" "^24.8.0"
+    "@jest/types" "^24.8.0"
+    chalk "^2.0.1"
+    co "^4.6.0"
+    expect "^24.8.0"
+    is-generator-fn "^2.0.0"
+    jest-each "^24.8.0"
+    jest-matcher-utils "^24.8.0"
+    jest-message-util "^24.8.0"
+    jest-snapshot "^24.8.0"
+    jest-util "^24.8.0"
+    pretty-format "^24.8.0"
+    stack-utils "^1.0.1"
+    throat "^4.0.0"
+
 jest-cli@^24.8.0:
   version "24.8.0"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-24.8.0.tgz#b075ac914492ed114fa338ade7362a301693e989"


### PR DESCRIPTION
#### Description of changes

Updates jest.config.js to recommend use of the jest-circus runner to enable tests to early-exit when beforeAll/beforeEach methods fail, per facebook/jest#2713

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: Fixes #0000
- [x] `yarn test` passes in all affected samples
- [x] Added any applicable tests
