### PR TITLE
Fix non-obvious index.html issues

### DIFF
--- a/typescript-selenium-webdriver/src/index.html
+++ b/typescript-selenium-webdriver/src/index.html
@@ -1,15 +1,16 @@
+<!DOCTYPE html>
 <html lang="en-US">
     <head>
         <title>Example page with some accessibility issues</title>
     </head>
     <body>
-        <h1>
-            This is a static sample page with some accessibility issues
-        </h1>
-        <ul>
-            <li>This text box has no accessible label: <input type="text"></li>
-            <li>This text's color contrast is too low: <span style="color: #A2A2A2">low-contrast text</span></li>
-            <li>This text has an invalid "role" attribute: <span role="invalid">span with invalid role</a></li>
-        </ul>
+        <main>
+            <h1>This is a static sample page with some accessibility issues</h1>
+            <ul>
+                <li>This text box has no accessible label: <input type="text"></li>
+                <li>This text's color contrast is too low: <span style="color: #A2A2A2">low-contrast text</span></li>
+                <li>This text has an invalid "role" attribute: <span role="invalid">span with invalid role</a></li>
+            </ul>
+        </main>
     </body>
 </html>

--- a/typescript-selenium-webdriver/tests/index.test.ts
+++ b/typescript-selenium-webdriver/tests/index.test.ts
@@ -66,7 +66,7 @@ describe('index.html', () => {
         const axeResults = await AxeBuilder(driver).analyze();
 
         // Write a test expectation that accounts for "known" issues we want to baseline
-        expect(axeResults.violations.length).toBe(5);
+        expect(axeResults.violations.length).toBe(3);
 
         // Write the axe results to a .sarif file, so we can use the SARIF Multitool to
         // apply a baseline file and show the results in the Scans tab in Azure Pipelines


### PR DESCRIPTION
#### Description of changes

When I was experimenting with different types of snapshotting/baselining behavior, I wanted it to be obvious to a non-expert user which detected failures were actually intentional. I thought it was a little more obvious to an unfamiliar reader for the 3 list items that are obviously examples to be the *only* examples caught by the tests.

This fixes the [region](https://dequeuniversity.com/rules/axe/3.2/region) and [landmark-one-main](https://dequeuniversity.com/rules/axe/3.2/landmark-one-main) violations, leaving exactly the one violation per bullet point that the bullet points self-describe.

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: Fixes #0000
- [x] `yarn test` passes in all affected samples
- [x] Added any applicable tests
