### PR TITLE
Add vscode launch.json tasks for Jest debugging

### DIFF
--- a/typescript-selenium-webdriver/.vscode/launch.json
+++ b/typescript-selenium-webdriver/.vscode/launch.json
@@ -1,0 +1,39 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        // See https://github.com/microsoft/vscode-recipes/tree/master/debugging-jest-tests
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest All",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": ["--runInBand"],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "windows": {
+              "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            }
+          },
+          {
+            "type": "node",
+            "request": "launch",
+            "name": "Jest Current File",
+            "program": "${workspaceFolder}/node_modules/.bin/jest",
+            "args": [
+              "${fileBasenameNoExtension}",
+              "--config",
+              "jest.config.js"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "disableOptimisticBPs": true,
+            "windows": {
+              "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+            }
+          }
+    ]
+}

--- a/typescript-selenium-webdriver/.vscode/launch.json
+++ b/typescript-selenium-webdriver/.vscode/launch.json
@@ -4,7 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
-        // See https://github.com/microsoft/vscode-recipes/tree/master/debugging-jest-tests
+        // From https://github.com/microsoft/vscode-recipes/tree/master/debugging-jest-tests
         {
             "type": "node",
             "request": "launch",


### PR DESCRIPTION
#### Description of changes

Adds standard .vscode launch tasks for debugging the Jest tests, from https://github.com/microsoft/vscode-recipes/tree/master/debugging-jest-tests

I'm undecided on whether it's actually appropriate to include this in the sample repo, since it's not *directly* required for running accessibility tests. Would appreciate reviewers' thoughts on whether we *should* include this, not just whether it's syntactically correct.

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: Fixes #0000
- [x] `yarn test` passes in all affected samples
- [x] Added any applicable tests
