### PR TITLE
Move driver.wait to beforeEach instead of separate test

### DIFF
--- a/typescript-selenium-webdriver/tests/index.test.ts
+++ b/typescript-selenium-webdriver/tests/index.test.ts
@@ -51,14 +51,10 @@ describe('index.html', () => {
         // Checking for a known element on the page in beforeEach serves two purposes:
         // * It acts as a sanity check that our browser automation setup basically works
         // * It ensures that the page is loaded before we run our accessibility scans
-        await driver.wait(until.elementLocated(By.css('main')));
+        await driver.wait(until.elementLocated(By.css('h1')));
     });
 
     it('only contains known accessibility violations', async () => {
-        // Ensure that the page is loaded and rendered
-        const header = await driver.wait(until.elementLocated(By.css('h1')));
-        await driver.wait(until.elementIsVisible(header));
-
         // Run an accessibility scan using axe-webdriverjs
         const axeResults = await AxeBuilder(driver).analyze();
 

--- a/typescript-selenium-webdriver/tests/index.test.ts
+++ b/typescript-selenium-webdriver/tests/index.test.ts
@@ -47,14 +47,11 @@ describe('index.html', () => {
         // See https://jestjs.io/docs/en/testing-frameworks for examples.
         const pageUnderTest = 'file://' + path.join(__dirname, '..', 'src', 'index.html');
         await driver.get(pageUnderTest);
-    });
 
-    it('renders the expected header text', async () => {
-        const header = await driver.wait(until.elementLocated(By.css('h1')));
-        await driver.wait(until.elementIsVisible(header));
-        const headerText = await header.getText();
-
-        expect(headerText).toEqual('This is a static sample page with some accessibility issues');
+        // Checking for a known element on the page in beforeEach serves two purposes:
+        // * It acts as a sanity check that our browser automation setup basically works
+        // * It ensures that the page is loaded before we run our accessibility scans
+        await driver.wait(until.elementLocated(By.css('main')));
     });
 
     it('only contains known accessibility violations', async () => {


### PR DESCRIPTION
#### Description of changes

During development of other snapshot/baselining changes that involved adding multiple test cases, I found that I wanted this wait call to be happening before every test rather than as an isolated sanity check in its own test. Moved it and updated comments accordingly.

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: Fixes #0000
- [x] `yarn test` passes in all affected samples
- [x] Added any applicable tests
