### PR TITLE
Add examples of baselining from a test with sarif multitool

### DIFF
--- a/typescript-selenium-webdriver/.gitignore
+++ b/typescript-selenium-webdriver/.gitignore
@@ -6,6 +6,7 @@ yarn-error.log*
 
 # Dependency directories
 node_modules/
+dotnet_tools/
 
 # Yarn Integrity file
 .yarn-integrity

--- a/typescript-selenium-webdriver/package.json
+++ b/typescript-selenium-webdriver/package.json
@@ -13,11 +13,17 @@
         "http-server": "^0.11.1",
         "jest": "^24.8.0",
         "jest-junit": "^6.4.0",
+        "jsonpath": "^1.0.1",
+        "rimraf": "^2.6.3",
         "selenium-webdriver": "^4.0.0-alpha.1",
         "ts-jest": "^24.0.2",
         "typescript": "^3.4.5"
     },
     "scripts": {
+        "check-dotnet-installed": "dotnet --version || >&2 echo 'This project requires the .NET Core SDK to be installed. See https://dotnet.microsoft.com/download/dotnet-core' && exit 1",
+        "clean-dotnet-tools": "rimraf ./dotnet_tools",
+        "preinstall": "yarn check-dotnet-installed && yarn clean-dotnet-tools",
+        "install": "dotnet tool install --tool-path ./dotnet_tools Sarif.Multitool --version 2.1.1",
         "serve": "http-server ./src",
         "test": "jest"
     }

--- a/typescript-selenium-webdriver/package.json
+++ b/typescript-selenium-webdriver/package.json
@@ -22,8 +22,8 @@
     "scripts": {
         "check-dotnet-installed": "dotnet --version || >&2 echo 'This project requires the .NET Core SDK to be installed. See https://dotnet.microsoft.com/download/dotnet-core' && exit 1",
         "clean-dotnet-tools": "rimraf ./dotnet_tools",
-        "preinstall": "yarn check-dotnet-installed && yarn clean-dotnet-tools",
-        "install": "dotnet tool install --tool-path ./dotnet_tools Sarif.Multitool --version 2.1.1",
+        "preinstall": "yarn check-dotnet-installed",
+        "install": "yarn clean-dotnet-tools && dotnet tool install --tool-path ./dotnet_tools Sarif.Multitool --version 2.1.1",
         "serve": "http-server ./src",
         "test": "jest"
     }

--- a/typescript-selenium-webdriver/tests/index.html_baseline.sarif
+++ b/typescript-selenium-webdriver/tests/index.html_baseline.sarif
@@ -1,0 +1,2615 @@
+{
+  "$schema": "http://json.schemastore.org/sarif-2.1.0-rtm.0",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "axe",
+          "fullName": "axe-core",
+          "version": "3.2.2",
+          "semanticVersion": "3.2.2",
+          "rules": [
+            {
+              "id": "aria-roles",
+              "name": "ARIA roles used must conform to valid values",
+              "fullDescription": {
+                "text": "Ensures all elements with a role attribute use a valid value"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/aria-roles?application=webdriverjs"
+            },
+            {
+              "id": "color-contrast",
+              "name": "Elements must have sufficient color contrast",
+              "fullDescription": {
+                "text": "Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/color-contrast?application=webdriverjs"
+            },
+            {
+              "id": "label",
+              "name": "Form elements must have labels",
+              "fullDescription": {
+                "text": "Ensures every form element has a label"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/label?application=webdriverjs"
+            },
+            {
+              "id": "landmark-one-main",
+              "name": "Document must have one main landmark",
+              "fullDescription": {
+                "text": "Ensures the document has only one main landmark and each iframe in the page has at most one main landmark"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/landmark-one-main?application=webdriverjs"
+            },
+            {
+              "id": "region",
+              "name": "All page content must be contained by landmarks",
+              "fullDescription": {
+                "text": "Ensures all page content is contained by landmarks"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/region?application=webdriverjs"
+            },
+            {
+              "id": "aria-hidden-body",
+              "name": "aria-hidden='true' must not be present on the document body",
+              "fullDescription": {
+                "text": "Ensures aria-hidden='true' is not present on the document body."
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/aria-hidden-body?application=webdriverjs"
+            },
+            {
+              "id": "aria-required-attr",
+              "name": "Required ARIA attributes must be provided",
+              "fullDescription": {
+                "text": "Ensures elements with ARIA roles have all required ARIA attributes"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/aria-required-attr?application=webdriverjs"
+            },
+            {
+              "id": "aria-required-children",
+              "name": "Certain ARIA roles must contain particular children",
+              "fullDescription": {
+                "text": "Ensures elements with an ARIA role that require child roles contain them"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/aria-required-children?application=webdriverjs"
+            },
+            {
+              "id": "aria-required-parent",
+              "name": "Certain ARIA roles must be contained by particular parents",
+              "fullDescription": {
+                "text": "Ensures elements with an ARIA role that require parent roles are contained by them"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/aria-required-parent?application=webdriverjs"
+            },
+            {
+              "id": "document-title",
+              "name": "Documents must have <title> element to aid in navigation",
+              "fullDescription": {
+                "text": "Ensures each HTML document contains a non-empty <title> element"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/document-title?application=webdriverjs"
+            },
+            {
+              "id": "empty-heading",
+              "name": "Headings must not be empty",
+              "fullDescription": {
+                "text": "Ensures headings have discernible text"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/empty-heading?application=webdriverjs"
+            },
+            {
+              "id": "form-field-multiple-labels",
+              "name": "Form field must not have multiple label elements",
+              "fullDescription": {
+                "text": "Ensures form field does not have multiple label elements"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/form-field-multiple-labels?application=webdriverjs"
+            },
+            {
+              "id": "heading-order",
+              "name": "Heading levels should only increase by one",
+              "fullDescription": {
+                "text": "Ensures the order of headings is semantically correct"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/heading-order?application=webdriverjs"
+            },
+            {
+              "id": "html-has-lang",
+              "name": "<html> element must have a lang attribute",
+              "fullDescription": {
+                "text": "Ensures every HTML document has a lang attribute"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/html-has-lang?application=webdriverjs"
+            },
+            {
+              "id": "html-lang-valid",
+              "name": "<html> element must have a valid value for the lang attribute",
+              "fullDescription": {
+                "text": "Ensures the lang attribute of the <html> element has a valid value"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/html-lang-valid?application=webdriverjs"
+            },
+            {
+              "id": "image-redundant-alt",
+              "name": "Text of buttons and links should not be repeated in the image alternative",
+              "fullDescription": {
+                "text": "Ensure button and link text is not repeated as image alternative"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/image-redundant-alt?application=webdriverjs"
+            },
+            {
+              "id": "label-title-only",
+              "name": "Form elements should have a visible label",
+              "fullDescription": {
+                "text": "Ensures that every form element is not solely labeled using the title or aria-describedby attributes"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/label-title-only?application=webdriverjs"
+            },
+            {
+              "id": "landmark-no-duplicate-banner",
+              "name": "Document must not have more than one banner landmark",
+              "fullDescription": {
+                "text": "Ensures the document has at most one banner landmark"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/landmark-no-duplicate-banner?application=webdriverjs"
+            },
+            {
+              "id": "landmark-no-duplicate-contentinfo",
+              "name": "Document must not have more than one contentinfo landmark",
+              "fullDescription": {
+                "text": "Ensures the document has at most one contentinfo landmark"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/landmark-no-duplicate-contentinfo?application=webdriverjs"
+            },
+            {
+              "id": "list",
+              "name": "<ul> and <ol> must only directly contain <li>, <script> or <template> elements",
+              "fullDescription": {
+                "text": "Ensures that lists are structured correctly"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/list?application=webdriverjs"
+            },
+            {
+              "id": "listitem",
+              "name": "<li> elements must be contained in a <ul> or <ol>",
+              "fullDescription": {
+                "text": "Ensures <li> elements are used semantically"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/listitem?application=webdriverjs"
+            },
+            {
+              "id": "page-has-heading-one",
+              "name": "Page must contain a level-one heading",
+              "fullDescription": {
+                "text": "Ensure that the page, or at least one of its frames contains a level-one heading"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/page-has-heading-one?application=webdriverjs"
+            },
+            {
+              "id": "accesskeys",
+              "name": "accesskey attribute value must be unique",
+              "fullDescription": {
+                "text": "Ensures every accesskey attribute value is unique"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/accesskeys?application=webdriverjs"
+            },
+            {
+              "id": "area-alt",
+              "name": "Active <area> elements must have alternate text",
+              "fullDescription": {
+                "text": "Ensures <area> elements of image maps have alternate text"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/area-alt?application=webdriverjs"
+            },
+            {
+              "id": "aria-allowed-attr",
+              "name": "Elements must only use allowed ARIA attributes",
+              "fullDescription": {
+                "text": "Ensures ARIA attributes are allowed for an element's role"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/aria-allowed-attr?application=webdriverjs"
+            },
+            {
+              "id": "aria-allowed-role",
+              "name": "ARIA role must be appropriate for the element",
+              "fullDescription": {
+                "text": "Ensures role attribute has an appropriate value for the element"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/aria-allowed-role?application=webdriverjs"
+            },
+            {
+              "id": "aria-dpub-role-fallback",
+              "name": "Unsupported DPUB ARIA roles should be used on elements with implicit fallback roles",
+              "fullDescription": {
+                "text": "Ensures unsupported DPUB roles are only used on elements with implicit fallback roles"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/aria-dpub-role-fallback?application=webdriverjs"
+            },
+            {
+              "id": "aria-hidden-focus",
+              "name": "ARIA hidden element must not contain focusable elements",
+              "fullDescription": {
+                "text": "Ensures aria-hidden elements do not contain focusable elements"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/aria-hidden-focus?application=webdriverjs"
+            },
+            {
+              "id": "aria-valid-attr-value",
+              "name": "ARIA attributes must conform to valid values",
+              "fullDescription": {
+                "text": "Ensures all ARIA attributes have valid values"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/aria-valid-attr-value?application=webdriverjs"
+            },
+            {
+              "id": "aria-valid-attr",
+              "name": "ARIA attributes must conform to valid names",
+              "fullDescription": {
+                "text": "Ensures attributes that begin with aria- are valid ARIA attributes"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/aria-valid-attr?application=webdriverjs"
+            },
+            {
+              "id": "autocomplete-valid",
+              "name": "autocomplete attribute must be used correctly",
+              "fullDescription": {
+                "text": "Ensure the autocomplete attribute is correct and suitable for the form field"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/autocomplete-valid?application=webdriverjs"
+            },
+            {
+              "id": "blink",
+              "name": "<blink> elements are deprecated and must not be used",
+              "fullDescription": {
+                "text": "Ensures <blink> elements are not used"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/blink?application=webdriverjs"
+            },
+            {
+              "id": "button-name",
+              "name": "Buttons must have discernible text",
+              "fullDescription": {
+                "text": "Ensures buttons have discernible text"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/button-name?application=webdriverjs"
+            },
+            {
+              "id": "bypass",
+              "name": "Page must have means to bypass repeated blocks",
+              "fullDescription": {
+                "text": "Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/bypass?application=webdriverjs"
+            },
+            {
+              "id": "checkboxgroup",
+              "name": "Checkbox inputs with the same name attribute value must be part of a group",
+              "fullDescription": {
+                "text": "Ensures related <input type=\"checkbox\"> elements have a group and that the group designation is consistent"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/checkboxgroup?application=webdriverjs"
+            },
+            {
+              "id": "definition-list",
+              "name": "<dl> elements must only directly contain properly-ordered <dt> and <dd> groups, <script> or <template> elements",
+              "fullDescription": {
+                "text": "Ensures <dl> elements are structured correctly"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/definition-list?application=webdriverjs"
+            },
+            {
+              "id": "dlitem",
+              "name": "<dt> and <dd> elements must be contained by a <dl>",
+              "fullDescription": {
+                "text": "Ensures <dt> and <dd> elements are contained by a <dl>"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/dlitem?application=webdriverjs"
+            },
+            {
+              "id": "duplicate-id-active",
+              "name": "IDs of active elements must be unique",
+              "fullDescription": {
+                "text": "Ensures every id attribute value of active elements is unique"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/duplicate-id-active?application=webdriverjs"
+            },
+            {
+              "id": "duplicate-id-aria",
+              "name": "IDs used in ARIA and labels must be unique",
+              "fullDescription": {
+                "text": "Ensures every id attribute value used in ARIA and in labels is unique"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/duplicate-id-aria?application=webdriverjs"
+            },
+            {
+              "id": "duplicate-id",
+              "name": "id attribute value must be unique",
+              "fullDescription": {
+                "text": "Ensures every id attribute value is unique"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/duplicate-id?application=webdriverjs"
+            },
+            {
+              "id": "frame-tested",
+              "name": "Frames must be tested with axe-core",
+              "fullDescription": {
+                "text": "Ensures <iframe> and <frame> elements contain the axe-core script"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/frame-tested?application=webdriverjs"
+            },
+            {
+              "id": "frame-title-unique",
+              "name": "Frames must have a unique title attribute",
+              "fullDescription": {
+                "text": "Ensures <iframe> and <frame> elements contain a unique title attribute"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/frame-title-unique?application=webdriverjs"
+            },
+            {
+              "id": "frame-title",
+              "name": "Frames must have title attribute",
+              "fullDescription": {
+                "text": "Ensures <iframe> and <frame> elements contain a non-empty title attribute"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/frame-title?application=webdriverjs"
+            },
+            {
+              "id": "html-xml-lang-mismatch",
+              "name": "HTML elements with lang and xml:lang must have the same base language",
+              "fullDescription": {
+                "text": "Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/html-xml-lang-mismatch?application=webdriverjs"
+            },
+            {
+              "id": "image-alt",
+              "name": "Images must have alternate text",
+              "fullDescription": {
+                "text": "Ensures <img> elements have alternate text or a role of none or presentation"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/image-alt?application=webdriverjs"
+            },
+            {
+              "id": "input-image-alt",
+              "name": "Image buttons must have alternate text",
+              "fullDescription": {
+                "text": "Ensures <input type=\"image\"> elements have alternate text"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/input-image-alt?application=webdriverjs"
+            },
+            {
+              "id": "landmark-banner-is-top-level",
+              "name": "Banner landmark must not be contained in another landmark",
+              "fullDescription": {
+                "text": "Ensures the banner landmark is at top level"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/landmark-banner-is-top-level?application=webdriverjs"
+            },
+            {
+              "id": "landmark-complementary-is-top-level",
+              "name": "Aside must not be contained in another landmark",
+              "fullDescription": {
+                "text": "Ensures the complementary landmark or aside is at top level"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/landmark-complementary-is-top-level?application=webdriverjs"
+            },
+            {
+              "id": "landmark-contentinfo-is-top-level",
+              "name": "Contentinfo landmark must not be contained in another landmark",
+              "fullDescription": {
+                "text": "Ensures the contentinfo landmark is at top level"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/landmark-contentinfo-is-top-level?application=webdriverjs"
+            },
+            {
+              "id": "landmark-main-is-top-level",
+              "name": "Main landmark must not be contained in another landmark",
+              "fullDescription": {
+                "text": "Ensures the main landmark is at top level"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/landmark-main-is-top-level?application=webdriverjs"
+            },
+            {
+              "id": "layout-table",
+              "name": "Layout tables must not use data table elements",
+              "fullDescription": {
+                "text": "Ensures presentational <table> elements do not use <th>, <caption> elements or the summary attribute"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/layout-table?application=webdriverjs"
+            },
+            {
+              "id": "link-name",
+              "name": "Links must have discernible text",
+              "fullDescription": {
+                "text": "Ensures links have discernible text"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/link-name?application=webdriverjs"
+            },
+            {
+              "id": "marquee",
+              "name": "<marquee> elements are deprecated and must not be used",
+              "fullDescription": {
+                "text": "Ensures <marquee> elements are not used"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/marquee?application=webdriverjs"
+            },
+            {
+              "id": "meta-refresh",
+              "name": "Timed refresh must not exist",
+              "fullDescription": {
+                "text": "Ensures <meta http-equiv=\"refresh\"> is not used"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/meta-refresh?application=webdriverjs"
+            },
+            {
+              "id": "meta-viewport-large",
+              "name": "Users should be able to zoom and scale the text up to 500%",
+              "fullDescription": {
+                "text": "Ensures <meta name=\"viewport\"> can scale a significant amount"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/meta-viewport-large?application=webdriverjs"
+            },
+            {
+              "id": "meta-viewport",
+              "name": "Zooming and scaling must not be disabled",
+              "fullDescription": {
+                "text": "Ensures <meta name=\"viewport\"> does not disable text scaling and zooming"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/meta-viewport?application=webdriverjs"
+            },
+            {
+              "id": "object-alt",
+              "name": "<object> elements must have alternate text",
+              "fullDescription": {
+                "text": "Ensures <object> elements have alternate text"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/object-alt?application=webdriverjs"
+            },
+            {
+              "id": "radiogroup",
+              "name": "Radio inputs with the same name attribute value must be part of a group",
+              "fullDescription": {
+                "text": "Ensures related <input type=\"radio\"> elements have a group and that the group designation is consistent"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/radiogroup?application=webdriverjs"
+            },
+            {
+              "id": "scope-attr-valid",
+              "name": "scope attribute should be used correctly",
+              "fullDescription": {
+                "text": "Ensures the scope attribute is used correctly on tables"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/scope-attr-valid?application=webdriverjs"
+            },
+            {
+              "id": "server-side-image-map",
+              "name": "Server-side image maps must not be used",
+              "fullDescription": {
+                "text": "Ensures that server-side image maps are not used"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/server-side-image-map?application=webdriverjs"
+            },
+            {
+              "id": "skip-link",
+              "name": "The skip-link target should exist and be focusable",
+              "fullDescription": {
+                "text": "Ensure all skip links have a focusable target"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/skip-link?application=webdriverjs"
+            },
+            {
+              "id": "tabindex",
+              "name": "Elements should not have tabindex greater than zero",
+              "fullDescription": {
+                "text": "Ensures tabindex attribute values are not greater than 0"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/tabindex?application=webdriverjs"
+            },
+            {
+              "id": "table-duplicate-name",
+              "name": "The <caption> element should not contain the same text as the summary attribute",
+              "fullDescription": {
+                "text": "Ensure that tables do not have the same summary and caption"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/table-duplicate-name?application=webdriverjs"
+            },
+            {
+              "id": "td-headers-attr",
+              "name": "All cells in a table element that use the headers attribute must only refer to other cells of that same table",
+              "fullDescription": {
+                "text": "Ensure that each cell in a table using the headers refers to another cell in that table"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/td-headers-attr?application=webdriverjs"
+            },
+            {
+              "id": "th-has-data-cells",
+              "name": "All th elements and elements with role=columnheader/rowheader must have data cells they describe",
+              "fullDescription": {
+                "text": "Ensure that each table header in a data table refers to data cells"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/th-has-data-cells?application=webdriverjs"
+            },
+            {
+              "id": "valid-lang",
+              "name": "lang attribute must have a valid value",
+              "fullDescription": {
+                "text": "Ensures lang attributes have valid values"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/valid-lang?application=webdriverjs"
+            },
+            {
+              "id": "video-caption",
+              "name": "<video> elements must have captions",
+              "fullDescription": {
+                "text": "Ensures <video> elements have captions"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/video-caption?application=webdriverjs"
+            },
+            {
+              "id": "video-description",
+              "name": "<video> elements must have an audio description track",
+              "fullDescription": {
+                "text": "Ensures <video> elements have audio descriptions"
+              },
+              "helpUri": "https://dequeuniversity.com/rules/axe/3.2/video-description?application=webdriverjs"
+            }
+          ],
+          "properties": {
+            "downloadUri": "https://www.deque.com/axe/"
+          }
+        }
+      },
+      "invocations": [
+        {
+          "startTimeUtc": "2019-05-22T00:42:35.744Z",
+          "endTimeUtc": "2019-05-22T00:42:35.744Z",
+          "executionSuccessful": true
+        }
+      ],
+      "artifacts": [
+        {
+          "location": {
+            "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+            "index": 0
+          },
+          "mimeType": "text/html",
+          "properties": {
+            "tags": [
+  "target"
+],
+            "title": ""
+          }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "aria-roles",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "Fix all of the following: Role must be one of the valid ARIA roles.",
+            "markdown": "Fix all of the following:\n- Role must be one of the valid ARIA roles"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "span[role=\"invalid\"]"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<span role=\"invalid\">span with invalid role</span>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "span[role=\"invalid\"]",
+            "ruleId": "aria-roles"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "color-contrast",
+          "ruleIndex": 1,
+          "level": "error",
+          "message": {
+            "text": "Fix any of the following: Element has insufficient color contrast of 2.55 (foreground color: #a2a2a2, background color: #ffffff, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1.",
+            "markdown": "Fix any of the following:\n- Element has insufficient color contrast of 2.55 (foreground color: #a2a2a2, background color: #ffffff, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "li:nth-child(2) > span"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<span style=\"color: #A2A2A2\">low-contrast text</span>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "li:nth-child(2) > span",
+            "ruleId": "color-contrast"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "label",
+          "ruleIndex": 2,
+          "level": "error",
+          "message": {
+            "text": "Fix any of the following: aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Form element does not have an implicit (wrapped) <label>. Form element does not have an explicit <label>. Element has no title attribute or the title attribute is empty.",
+            "markdown": "Fix any of the following:\n- aria-label attribute does not exist or is empty\n- aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty\n- Form element does not have an implicit (wrapped) &lt;label>\n- Form element does not have an explicit &lt;label>\n- Element has no title attribute or the title attribute is empty"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "input"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<input type=\"text\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "input",
+            "ruleId": "label"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "landmark-one-main",
+          "ruleIndex": 3,
+          "level": "error",
+          "message": {
+            "text": "Fix all of the following: Document does not have a main landmark.",
+            "markdown": "Fix all of the following:\n- Document does not have a main landmark"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "html"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<html lang=\"en-US\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "html",
+            "ruleId": "landmark-one-main"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "region",
+          "ruleIndex": 4,
+          "level": "error",
+          "message": {
+            "text": "Fix any of the following: Some page content is not contained by landmarks.",
+            "markdown": "Fix any of the following:\n- Some page content is not contained by landmarks"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "html"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<html lang=\"en-US\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "html",
+            "ruleId": "region"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "aria-hidden-body",
+          "ruleIndex": 5,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: No aria-hidden attribute is present on document body.",
+            "markdown": "The following tests passed:\n- No aria-hidden attribute is present on document body"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "body"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<body>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "body",
+            "ruleId": "aria-hidden-body"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "aria-required-attr",
+          "ruleIndex": 6,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: All required ARIA attributes are present.",
+            "markdown": "The following tests passed:\n- All required ARIA attributes are present"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "span[role=\"invalid\"]"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<span role=\"invalid\">span with invalid role</span>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "span[role=\"invalid\"]",
+            "ruleId": "aria-required-attr"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "aria-required-children",
+          "ruleIndex": 7,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Required ARIA children are present.",
+            "markdown": "The following tests passed:\n- Required ARIA children are present"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "span[role=\"invalid\"]"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<span role=\"invalid\">span with invalid role</span>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "span[role=\"invalid\"]",
+            "ruleId": "aria-required-children"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "aria-required-parent",
+          "ruleIndex": 8,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Required ARIA parent role present.",
+            "markdown": "The following tests passed:\n- Required ARIA parent role present"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "span[role=\"invalid\"]"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<span role=\"invalid\">span with invalid role</span>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "span[role=\"invalid\"]",
+            "ruleId": "aria-required-parent"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "color-contrast",
+          "ruleIndex": 1,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Element has sufficient color contrast of 21.",
+            "markdown": "The following tests passed:\n- Element has sufficient color contrast of 21"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "h1"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<h1>\n            This is a static sample page with some accessibility issues\n        </h1>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "h1",
+            "ruleId": "color-contrast"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "color-contrast",
+          "ruleIndex": 1,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Element has sufficient color contrast of 21.",
+            "markdown": "The following tests passed:\n- Element has sufficient color contrast of 21"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "li:nth-child(1)"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<li>This text box has no accessible label: <input type=\"text\"></li>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "li:nth-child(1)",
+            "ruleId": "color-contrast"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "color-contrast",
+          "ruleIndex": 1,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Element has sufficient color contrast of 21.",
+            "markdown": "The following tests passed:\n- Element has sufficient color contrast of 21"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "input"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<input type=\"text\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "input",
+            "ruleId": "color-contrast"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "color-contrast",
+          "ruleIndex": 1,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Element has sufficient color contrast of 21.",
+            "markdown": "The following tests passed:\n- Element has sufficient color contrast of 21"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "li:nth-child(2)"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<li>This text's color contrast is too low: <span style=\"color: #A2A2A2\">low-contrast text</span></li>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "li:nth-child(2)",
+            "ruleId": "color-contrast"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "color-contrast",
+          "ruleIndex": 1,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Element has sufficient color contrast of 21.",
+            "markdown": "The following tests passed:\n- Element has sufficient color contrast of 21"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "li:nth-child(3)"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<li>This text has an invalid \"role\" attribute: <span role=\"invalid\">span with invalid role</span></li>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "li:nth-child(3)",
+            "ruleId": "color-contrast"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "color-contrast",
+          "ruleIndex": 1,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Element has sufficient color contrast of 21.",
+            "markdown": "The following tests passed:\n- Element has sufficient color contrast of 21"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "span[role=\"invalid\"]"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<span role=\"invalid\">span with invalid role</span>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "span[role=\"invalid\"]",
+            "ruleId": "color-contrast"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "document-title",
+          "ruleIndex": 9,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Document has a non-empty <title> element.",
+            "markdown": "The following tests passed:\n- Document has a non-empty &lt;title> element"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "html"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<html lang=\"en-US\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "html",
+            "ruleId": "document-title"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "empty-heading",
+          "ruleIndex": 10,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Element has text that is visible to screen readers.",
+            "markdown": "The following tests passed:\n- Element has text that is visible to screen readers"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "h1"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<h1>\n            This is a static sample page with some accessibility issues\n        </h1>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "h1",
+            "ruleId": "empty-heading"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "form-field-multiple-labels",
+          "ruleIndex": 11,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Form field does not have multiple label elements.",
+            "markdown": "The following tests passed:\n- Form field does not have multiple label elements"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "input"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<input type=\"text\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "input",
+            "ruleId": "form-field-multiple-labels"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "heading-order",
+          "ruleIndex": 12,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Heading order valid.",
+            "markdown": "The following tests passed:\n- Heading order valid"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "h1"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<h1>\n            This is a static sample page with some accessibility issues\n        </h1>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "h1",
+            "ruleId": "heading-order"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "html-has-lang",
+          "ruleIndex": 13,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: The <html> element has a lang attribute.",
+            "markdown": "The following tests passed:\n- The &lt;html> element has a lang attribute"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "html"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<html lang=\"en-US\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "html",
+            "ruleId": "html-has-lang"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "html-lang-valid",
+          "ruleIndex": 14,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Value of lang attribute is included in the list of valid languages.",
+            "markdown": "The following tests passed:\n- Value of lang attribute is included in the list of valid languages"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "html"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<html lang=\"en-US\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "html",
+            "ruleId": "html-lang-valid"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "image-redundant-alt",
+          "ruleIndex": 15,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Element does not duplicate existing text in <img> alt text.",
+            "markdown": "The following tests passed:\n- Element does not duplicate existing text in &lt;img> alt text"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "li:nth-child(1)"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<li>This text box has no accessible label: <input type=\"text\"></li>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "li:nth-child(1)",
+            "ruleId": "image-redundant-alt"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "image-redundant-alt",
+          "ruleIndex": 15,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Element does not duplicate existing text in <img> alt text.",
+            "markdown": "The following tests passed:\n- Element does not duplicate existing text in &lt;img> alt text"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "li:nth-child(2)"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<li>This text's color contrast is too low: <span style=\"color: #A2A2A2\">low-contrast text</span></li>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "li:nth-child(2)",
+            "ruleId": "image-redundant-alt"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "image-redundant-alt",
+          "ruleIndex": 15,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Element does not duplicate existing text in <img> alt text.",
+            "markdown": "The following tests passed:\n- Element does not duplicate existing text in &lt;img> alt text"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "li:nth-child(3)"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<li>This text has an invalid \"role\" attribute: <span role=\"invalid\">span with invalid role</span></li>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "li:nth-child(3)",
+            "ruleId": "image-redundant-alt"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "label-title-only",
+          "ruleIndex": 16,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Form element does not solely use title attribute for its label.",
+            "markdown": "The following tests passed:\n- Form element does not solely use title attribute for its label"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "input"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<input type=\"text\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "input",
+            "ruleId": "label-title-only"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "landmark-no-duplicate-banner",
+          "ruleIndex": 17,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Document does not have more than one banner landmark.",
+            "markdown": "The following tests passed:\n- Document does not have more than one banner landmark"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "html"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<html lang=\"en-US\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "html",
+            "ruleId": "landmark-no-duplicate-banner"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "landmark-no-duplicate-contentinfo",
+          "ruleIndex": 18,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Document does not have more than one contentinfo landmark.",
+            "markdown": "The following tests passed:\n- Document does not have more than one contentinfo landmark"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "html"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<html lang=\"en-US\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "html",
+            "ruleId": "landmark-no-duplicate-contentinfo"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "list",
+          "ruleIndex": 19,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: List element only has direct children that are allowed inside <li> elements.",
+            "markdown": "The following tests passed:\n- List element only has direct children that are allowed inside &lt;li> elements"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "ul"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<ul>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "ul",
+            "ruleId": "list"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "listitem",
+          "ruleIndex": 20,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: List item has a <ul>, <ol> or role=\"list\" parent element.",
+            "markdown": "The following tests passed:\n- List item has a &lt;ul>, &lt;ol> or role=\"list\" parent element"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "li:nth-child(1)"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<li>This text box has no accessible label: <input type=\"text\"></li>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "li:nth-child(1)",
+            "ruleId": "listitem"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "listitem",
+          "ruleIndex": 20,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: List item has a <ul>, <ol> or role=\"list\" parent element.",
+            "markdown": "The following tests passed:\n- List item has a &lt;ul>, &lt;ol> or role=\"list\" parent element"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "li:nth-child(2)"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<li>This text's color contrast is too low: <span style=\"color: #A2A2A2\">low-contrast text</span></li>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "li:nth-child(2)",
+            "ruleId": "listitem"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "listitem",
+          "ruleIndex": 20,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: List item has a <ul>, <ol> or role=\"list\" parent element.",
+            "markdown": "The following tests passed:\n- List item has a &lt;ul>, &lt;ol> or role=\"list\" parent element"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "li:nth-child(3)"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<li>This text has an invalid \"role\" attribute: <span role=\"invalid\">span with invalid role</span></li>"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "li:nth-child(3)",
+            "ruleId": "listitem"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "page-has-heading-one",
+          "ruleIndex": 21,
+          "kind": "pass",
+          "level": "none",
+          "message": {
+            "text": "The following tests passed: Page has at least one level-one heading.",
+            "markdown": "The following tests passed:\n- Page has at least one level-one heading"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "file:///Q:/repos/axe-pipelines-samples/typescript-selenium-webdriver/src/index.html",
+                  "index": 0
+                }
+              },
+              "logicalLocation": {
+                "fullyQualifiedName": "html"
+              },
+              "annotations": [
+                {
+                  "snippet": {
+                    "text": "<html lang=\"en-US\">"
+                  }
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "fullyQualifiedLogicalName": "html",
+            "ruleId": "page-has-heading-one"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "accesskeys",
+          "ruleIndex": 22,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "accesskeys"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "area-alt",
+          "ruleIndex": 23,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "area-alt"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "aria-allowed-attr",
+          "ruleIndex": 24,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "aria-allowed-attr"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "aria-allowed-role",
+          "ruleIndex": 25,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "aria-allowed-role"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "aria-dpub-role-fallback",
+          "ruleIndex": 26,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "aria-dpub-role-fallback"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "aria-hidden-focus",
+          "ruleIndex": 27,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "aria-hidden-focus"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "aria-valid-attr-value",
+          "ruleIndex": 28,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "aria-valid-attr-value"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "aria-valid-attr",
+          "ruleIndex": 29,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "aria-valid-attr"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "autocomplete-valid",
+          "ruleIndex": 30,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "autocomplete-valid"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "blink",
+          "ruleIndex": 31,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "blink"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "button-name",
+          "ruleIndex": 32,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "button-name"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "bypass",
+          "ruleIndex": 33,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "bypass"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "checkboxgroup",
+          "ruleIndex": 34,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "checkboxgroup"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "definition-list",
+          "ruleIndex": 35,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "definition-list"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "dlitem",
+          "ruleIndex": 36,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "dlitem"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "duplicate-id-active",
+          "ruleIndex": 37,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "duplicate-id-active"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "duplicate-id-aria",
+          "ruleIndex": 38,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "duplicate-id-aria"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "duplicate-id",
+          "ruleIndex": 39,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "duplicate-id"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "frame-tested",
+          "ruleIndex": 40,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "frame-tested"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "frame-title-unique",
+          "ruleIndex": 41,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "frame-title-unique"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "frame-title",
+          "ruleIndex": 42,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "frame-title"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "html-xml-lang-mismatch",
+          "ruleIndex": 43,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "html-xml-lang-mismatch"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "image-alt",
+          "ruleIndex": 44,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "image-alt"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "input-image-alt",
+          "ruleIndex": 45,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "input-image-alt"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "landmark-banner-is-top-level",
+          "ruleIndex": 46,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "landmark-banner-is-top-level"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "landmark-complementary-is-top-level",
+          "ruleIndex": 47,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "landmark-complementary-is-top-level"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "landmark-contentinfo-is-top-level",
+          "ruleIndex": 48,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "landmark-contentinfo-is-top-level"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "landmark-main-is-top-level",
+          "ruleIndex": 49,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "landmark-main-is-top-level"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "layout-table",
+          "ruleIndex": 50,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "layout-table"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "link-name",
+          "ruleIndex": 51,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "link-name"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "marquee",
+          "ruleIndex": 52,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "marquee"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "meta-refresh",
+          "ruleIndex": 53,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "meta-refresh"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "meta-viewport-large",
+          "ruleIndex": 54,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "meta-viewport-large"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "meta-viewport",
+          "ruleIndex": 55,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "meta-viewport"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "object-alt",
+          "ruleIndex": 56,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "object-alt"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "radiogroup",
+          "ruleIndex": 57,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "radiogroup"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "scope-attr-valid",
+          "ruleIndex": 58,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "scope-attr-valid"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "server-side-image-map",
+          "ruleIndex": 59,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "server-side-image-map"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "skip-link",
+          "ruleIndex": 60,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "skip-link"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "tabindex",
+          "ruleIndex": 61,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "tabindex"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "table-duplicate-name",
+          "ruleIndex": 62,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "table-duplicate-name"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "td-headers-attr",
+          "ruleIndex": 63,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "td-headers-attr"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "th-has-data-cells",
+          "ruleIndex": 64,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "th-has-data-cells"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "valid-lang",
+          "ruleIndex": 65,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "valid-lang"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "video-caption",
+          "ruleIndex": 66,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "video-caption"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        },
+        {
+          "ruleId": "video-description",
+          "ruleIndex": 67,
+          "kind": "notApplicable",
+          "level": "none",
+          "message": {
+            "text": "[No message provided]."
+          },
+          "partialFingerprints": {
+            "ruleId": "video-description"
+          },
+          "properties": {
+            "tags": [
+  "Accessibility"
+]
+          }
+        }
+      ],
+      "columnKind": "utf16CodeUnits"
+    }
+  ]
+}

--- a/typescript-selenium-webdriver/yarn.lock
+++ b/typescript-selenium-webdriver/yarn.lock
@@ -370,6 +370,11 @@
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
   integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
 
+JSONSelect@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/JSONSelect/-/JSONSelect-0.4.0.tgz#a08edcc67eb3fcbe99ed630855344a0cf282bb8d"
+  integrity sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40=
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -745,6 +750,11 @@ ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
+cjson@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cjson/-/cjson-0.2.1.tgz#73cd8aad65d9e1505f9af1744d3b79c1527682a5"
+  integrity sha1-c82KrWXZ4VBfmvF0TTt5wVJ2gqU=
+
 class-utils@^0.3.5:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
@@ -793,6 +803,11 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+colors@0.5.x:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-0.5.1.tgz#7d0023eaeb154e8ee9fce75dcb923d0ed1667774"
+  integrity sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=
 
 colors@1.0.3:
   version "1.0.3"
@@ -999,6 +1014,11 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
+ebnf-parser@~0.1.9:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/ebnf-parser/-/ebnf-parser-0.1.10.tgz#cd1f6ba477c5638c40c97ed9b572db5bab5d8331"
+  integrity sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE=
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
@@ -1057,7 +1077,17 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-escodegen@^1.9.1:
+escodegen@0.0.21:
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-0.0.21.tgz#53d652cfa1030388279458a5266c5ffc709c63c3"
+  integrity sha1-U9ZSz6EDA4gnlFilJmxf/HCcY8M=
+  dependencies:
+    esprima "~1.0.2"
+    estraverse "~0.0.4"
+  optionalDependencies:
+    source-map ">= 0.1.2"
+
+escodegen@^1.8.1, escodegen@^1.9.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.1.tgz#c485ff8d6b4cdb89e27f4a856e91f118401ca510"
   integrity sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==
@@ -1069,6 +1099,16 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+esprima@1.0.x, esprima@~1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
+  integrity sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=
+
+esprima@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.2.2.tgz#76a0fd66fcfe154fd292667dc264019750b1657b"
+  integrity sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs=
+
 esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
@@ -1078,6 +1118,11 @@ estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
   integrity sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=
+
+estraverse@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-0.0.4.tgz#01a0932dfee574684a598af5a67c3bf9b6428db2"
+  integrity sha1-AaCTLf7ldGhKWYr1pnw7+bZCjbI=
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -2115,6 +2160,28 @@ jest@^24.8.0:
     import-local "^2.0.0"
     jest-cli "^24.8.0"
 
+jison-lex@0.2.x:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/jison-lex/-/jison-lex-0.2.1.tgz#ac4b815e8cce5132eb12b5dfcfe8d707b8844dfe"
+  integrity sha1-rEuBXozOUTLrErXfz+jXB7iETf4=
+  dependencies:
+    lex-parser "0.1.x"
+    nomnom "1.5.2"
+
+jison@0.4.13:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/jison/-/jison-0.4.13.tgz#9041707d62241367f58834532b9f19c2c36fac78"
+  integrity sha1-kEFwfWIkE2f1iDRTK58ZwsNvrHg=
+  dependencies:
+    JSONSelect "0.4.0"
+    cjson "~0.2.1"
+    ebnf-parser "~0.1.9"
+    escodegen "0.0.21"
+    esprima "1.0.x"
+    jison-lex "0.2.x"
+    lex-parser "~0.1.3"
+    nomnom "1.5.2"
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -2189,6 +2256,16 @@ json5@2.x, json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
+jsonpath@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jsonpath/-/jsonpath-1.0.1.tgz#fde977c5a64614aa8dde61a84b9b076d2b9c38ce"
+  integrity sha512-HY5kSg82LHIs0r0h9gYBwpNc1w1qGY0qJ7al01W1bJltsN2lp+mjjA/a79gXWuvD6Xf8oPkD2d5uKMZQXTGzqA==
+  dependencies:
+    esprima "1.2.2"
+    jison "0.4.13"
+    static-eval "2.0.2"
+    underscore "1.7.0"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -2262,6 +2339,11 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lex-parser@0.1.x, lex-parser@~0.1.3:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/lex-parser/-/lex-parser-0.1.4.tgz#64c4f025f17fd53bfb45763faeb16f015a747550"
+  integrity sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA=
 
 lie@~3.3.0:
   version "3.3.0"
@@ -2545,6 +2627,14 @@ node-pre-gyp@^0.12.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+nomnom@1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.5.2.tgz#f4345448a853cfbd5c0d26320f2477ab0526fe2f"
+  integrity sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=
+  dependencies:
+    colors "0.5.x"
+    underscore "1.1.x"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -3282,6 +3372,11 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
   integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
 
+"source-map@>= 0.1.2":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -3344,6 +3439,13 @@ stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
+static-eval@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/static-eval/-/static-eval-2.0.2.tgz#2d1759306b1befa688938454c546b7871f806a42"
+  integrity sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==
+  dependencies:
+    escodegen "^1.8.1"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -3589,6 +3691,16 @@ uglify-js@^3.1.4:
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"
+
+underscore@1.1.x:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.1.7.tgz#40bab84bad19d230096e8d6ef628bff055d83db0"
+  integrity sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA=
+
+underscore@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
+  integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
 
 union-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### Description of changes

This shows how you'd pull down the SARIF multitool NuGet package from a npm install script (similar strategy to how puppeteer pulls down a chrome installer) and then invoke it from a test method to do baselining.

I marked this do not merge because I don't think this is really ready for us to recommend as-is; I think there's enough boilerplate here that we'd want to encapsulate it in a sarif-multitool wrapper package. We'd also want that so that a user could express it as a devDependency; the strategy as used here essentially makes it a non-dev dependency, which would not be a good practice for, eg, a library of react components.

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: Fixes #0000
- [x] `yarn test` passes in all affected samples
- [x] Added any applicable tests
