### PR TITLE
Clean up readme usability issues caught during demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Automated accessibility tests can detect some common accessibility problems such
 
 ## Available samples
 
-|Sample|Description|
-|------|-----------|
-|[typescript-selenium-webdriver](./typescript-selenium-webdriver/README.md)|Uses [jest](https://jestjs.io/), [Selenium](https://www.seleniumhq.org) and [axe for Web](https://www.deque.com/axe/axe-for-web/) to test a web page for accessibility issues. Also demonstrates how to visualize issues and baseline pre-existing failures using [SARIF](https://sarifweb.azurewebsites.net/).
+* **[typescript-selenium-webdriver](./typescript-selenium-webdriver/README.md)**: Uses [Typescript](https://typescriptlang.org), [Jest](https://jestjs.io/), [Selenium](https://www.seleniumhq.org), and [axe-webdriverjs](https://www.npmjs.com/package/axe-webdriverjs) to test a web page for accessibility issues. Shows how to baseline existing failures with [Jest Snapshot Testing](https://jestjs.io/docs/en/snapshot-testing) and how to visualize failures in [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) using [SARIF](https://sarifweb.azurewebsites.net/).
 
 *Are we missing a sample you'd like to see? [File a sample request](https://github.com/microsoft/axe-pipelines-samples/issues/new?assignees=&labels=sample_request&template=feature_request.md&title=Sample+Request%3A+%3Csample+name+here%3E) or [submit a pull request](./CONTRIBUTING.md)!*
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Automated accessibility tests can detect some common accessibility problems such
 
 ## Available samples
 
-* **[typescript-selenium-webdriver](./typescript-selenium-webdriver/README.md)**: Uses [Typescript](https://typescriptlang.org), [Jest](https://jestjs.io/), [Selenium](https://www.seleniumhq.org), and [axe-webdriverjs](https://www.npmjs.com/package/axe-webdriverjs) to test a web page for accessibility issues. Shows how to baseline existing failures with [Jest Snapshot Testing](https://jestjs.io/docs/en/snapshot-testing) and how to visualize failures in [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) using [SARIF](https://sarifweb.azurewebsites.net/).
+* **[typescript-selenium-webdriver](./typescript-selenium-webdriver/README.md)**: Uses [TypeScript](https://typescriptlang.org), [Jest](https://jestjs.io/), [Selenium](https://www.seleniumhq.org), and [axe-webdriverjs](https://www.npmjs.com/package/axe-webdriverjs) to test a web page for accessibility issues. Shows how to baseline existing failures with [Jest Snapshot Testing](https://jestjs.io/docs/en/snapshot-testing) and how to visualize failures in [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) using [SARIF](https://sarifweb.azurewebsites.net/).
 
 *Are we missing a sample you'd like to see? [File a sample request](https://github.com/microsoft/axe-pipelines-samples/issues/new?assignees=&labels=sample_request&template=feature_request.md&title=Sample+Request%3A+%3Csample+name+here%3E) or [submit a pull request](./CONTRIBUTING.md)!*
 

--- a/typescript-selenium-webdriver/README.md
+++ b/typescript-selenium-webdriver/README.md
@@ -8,7 +8,7 @@ The individual files in the sample contain comments that explain the important p
 
 Some good places to start reading are:
 
-* [tests/index.test.ts](./tests/index.test.ts): The example tests in here demonstrate opening [src/index.html](./src/index.html) in a browser with Selenium and run accessibility scans with axe-webdriverjs
+* [tests/index.test.ts](./tests/index.test.ts): Jest test file that opens [src/index.html](./src/index.html) in a browser with Selenium and runs accessibility scans against it with axe-webdriverjs
 * [azure-pipelines.yml](./azure-pipelines.yml): Azure Pipelines config file that sets up our Continuous Integration and Pull Request builds
 * [jest.config.js](./jest.config.js): Jest configuration file that enables Typescript (using ts-jest) and test result reporting in Azure Pipelines (using jest-junit)
 

--- a/typescript-selenium-webdriver/README.md
+++ b/typescript-selenium-webdriver/README.md
@@ -8,9 +8,8 @@ This sample demonstrates how you might set up a CI build for a simple, static ht
 * [Jest](https://jestjs.io/) as our test framework, with [Jest Snapshot Testing](https://jestjs.io/docs/en/snapshot-testing) for baselining
 * [selenium-webdriver](https://www.npmjs.com/package/selenium-webdriver) to automate browsing to the page from the tests
 * [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs) to run an axe accessibility scan on the page from the Selenium browser
-* [axe-sarif-converter](https://github.com/microsoft/axe-sarif-converter) and [Sarif.Multitool](https://www.nuget.org/packages/Sarif.Multitool) to compare the scan results to a checked-in baseline
 * [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) to run the tests in a CI build with every Pull Request
-* [Sarif Viewer Build Tab](https://marketplace.visualstudio.com/items?itemName=sariftools.sarif-viewer-build-tab) to visualize the baselined results in Azure Pipelines
+* [axe-sarif-converter](https://github.com/microsoft/axe-sarif-converter) and [Sarif Viewer Build Tab](https://marketplace.visualstudio.com/items?itemName=sariftools.sarif-viewer-build-tab) to visualize the results in Azure Pipelines
 
 ## See it in action in Azure Pipelines
 

--- a/typescript-selenium-webdriver/README.md
+++ b/typescript-selenium-webdriver/README.md
@@ -2,6 +2,16 @@
 
 This sample demonstrates how you might set up a CI build for a simple, static html page to perform end to end accessibility tests in a browser, including how to suppress pre-existing or third-party failures using [Jest Snapshot Testing](https://jestjs.io/docs/en/snapshot-testing).
 
+## Getting Started
+
+The individual files in the sample contain comments that explain the important parts of each file in context.
+
+Some good places to start reading are:
+
+* [tests/index.test.ts](./tests/index.test.ts): The example tests in here demonstrate opening [src/index.html](./src/index.html) in a browser with Selenium and run accessibility scans with axe-webdriverjs
+* [azure-pipelines.yml](./azure-pipelines.yml): Azure Pipelines config file that sets up our Continuous Integration and Pull Request builds
+* [jest.config.js](./jest.config.js): Jest configuration file that enables Typescript (using ts-jest) and test result reporting in Azure Pipelines (using jest-junit)
+
 ## Tools and libraries used
 
 * [Typescript](https://www.typescriptlang.org/) to author our test code

--- a/typescript-selenium-webdriver/README.md
+++ b/typescript-selenium-webdriver/README.md
@@ -10,12 +10,12 @@ Some good places to start reading are:
 
 * [tests/index.test.ts](./tests/index.test.ts): Jest test file that opens [src/index.html](./src/index.html) in a browser with Selenium and runs accessibility scans against it with axe-webdriverjs
 * [azure-pipelines.yml](./azure-pipelines.yml): Azure Pipelines config file that sets up our Continuous Integration and Pull Request builds
-* [jest.config.js](./jest.config.js): Jest configuration file that enables Typescript (using ts-jest) and test result reporting in Azure Pipelines (using jest-junit)
+* [jest.config.js](./jest.config.js): Jest configuration file that enables TypeScript (using ts-jest) and test result reporting in Azure Pipelines (using jest-junit)
 
 ## Tools and libraries used
 
-* [Typescript](https://www.typescriptlang.org/) to author our test code
-* [Jest](https://jestjs.io/) as our test framework, with [Jest Snapshot Testing](https://jestjs.io/docs/en/snapshot-testing) for baselining and [ts-jest](https://www.npmjs.com/package/ts-jest) for Typescript support
+* [TypeScript](https://www.typescriptlang.org/) to author our test code
+* [Jest](https://jestjs.io/) as our test framework, with [Jest Snapshot Testing](https://jestjs.io/docs/en/snapshot-testing) for baselining and [ts-jest](https://www.npmjs.com/package/ts-jest) for TypeScript support
 * [selenium-webdriver](https://www.npmjs.com/package/selenium-webdriver) to automate browsing to the page from the tests
 * [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs) to run an axe accessibility scan on the page from the Selenium browser
 * [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) to run the tests in a CI build with every Pull Request

--- a/typescript-selenium-webdriver/README.md
+++ b/typescript-selenium-webdriver/README.md
@@ -4,8 +4,8 @@ This sample demonstrates how you might set up a CI build for a simple, static ht
 
 ## Tools and libraries used
 
-* [typescript](https://www.typescriptlang.org/) to author our test code
-* [Jest](https://jestjs.io/) as our test framework, with [Jest Snapshot Testing](https://jestjs.io/docs/en/snapshot-testing) for baselining
+* [Typescript](https://www.typescriptlang.org/) to author our test code
+* [Jest](https://jestjs.io/) as our test framework, with [Jest Snapshot Testing](https://jestjs.io/docs/en/snapshot-testing) for baselining and [ts-jest](https://www.npmjs.com/package/ts-jest) for Typescript support
 * [selenium-webdriver](https://www.npmjs.com/package/selenium-webdriver) to automate browsing to the page from the tests
 * [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs) to run an axe accessibility scan on the page from the Selenium browser
 * [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) to run the tests in a CI build with every Pull Request

--- a/typescript-selenium-webdriver/package.json
+++ b/typescript-selenium-webdriver/package.json
@@ -1,7 +1,7 @@
 {
     "name": "typescript-selenium-webdriver",
     "version": "0.0.0",
-    "description": "A typescript sample using webdriverjs with selenium",
+    "description": "Sample project that demonstrates accessibility testing with TypeScript, Jest, Selenium, axe-webdriver, SARIF, and Azure Pipelines.",
     "private": true,
     "dependencies": {},
     "devDependencies": {

--- a/typescript-selenium-webdriver/tsconfig.json
+++ b/typescript-selenium-webdriver/tsconfig.json
@@ -1,5 +1,0 @@
-{
-    "compilerOptions": {
-        "outDir": "./dist/",
-    },
-}


### PR DESCRIPTION
#### Description of changes

Cleans up a few usability issues we caught while doing a demo trial run this afternoon. Specifically:

* Replaces the table in the root readme with a list (JAWS didn't cooperate very well with the table, and it also rendered poorly on mobile)
* Adds a "Getting Started" section to the sample's readme that points the user to particularly notable files to read
* Removes an unnecessary/leftover `tsconfig.json` file
* Removes readme wording suggesting that we've already implemented sarif multitool baselining examples

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: Fixes #0000
- [x] `yarn test` passes in all affected samples
- [x] Added any applicable tests
