### PR TITLE
fix: update "run tests" instructions to use local instead of global jest

### DIFF
--- a/typescript-selenium-webdriver/README.md
+++ b/typescript-selenium-webdriver/README.md
@@ -60,7 +60,7 @@ Detailed accessibliity scan information also appears in the Scans tab, courtesy 
 1. Run the tests!
 
    ```sh
-   jest
+   yarn test # or npm test
    ```
 
    ![Screenshot of jest command showing all tests passing](./assets/screenshot-jest-success.png)


### PR DESCRIPTION
#### Description of changes

Updates README "Run the tests!" section to run the locally installed jest instead of the globally installed jest

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: Fixes #31
- [x] `yarn test` passes in all affected samples
- [x] Added any applicable tests
