### PR TITLE
docs: add more detail to comment about localhost test server usage

### DIFF
--- a/typescript-selenium-webdriver/tests/index.test.ts
+++ b/typescript-selenium-webdriver/tests/index.test.ts
@@ -40,10 +40,11 @@ describe('index.html', () => {
     beforeEach(async () => {
         // For simplicity, we're pointing our test browser directly to a static html file on disk.
         //
-        // In a real project, you would probably use a localhost http server (Express.js, for example)
-        // and point selenium-webdriver to a http://localhost link.
+        // In a project with more complex hosting needs, you might instead start up a localhost http server
+        // from your test's beforeAll block, and point your test cases to a http://localhost link.
         //
-        // See https://jestjs.io/docs/en/testing-frameworks for examples.
+        // Some common node.js libraries for hosting this sort of localhost http server include Express.js,
+        // http-server, and Koa. See https://jestjs.io/docs/en/testing-frameworks for more examples.
         const pageUnderTest = 'file://' + path.join(__dirname, '..', 'src', 'index.html');
         await driver.get(pageUnderTest);
 


### PR DESCRIPTION
#### Description of changes

Updates the comments about using a localhost test server to be more perscriptive about recommendations for how to set that up (noting where in the code you would do it and offering examples of libraries to use).

For reviewers: I'm interested both in review of the text change itself, but also review of whether we think updating the comment like this is likely to be sufficient to consider #25 closed. I'm on the fence; I'm not sure we really want a full example with a test server to be in scope for this sample, but I'm also not sure this update will be enough to resolve the user question as is

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: Fixes #25
- [x] `yarn test` passes in all affected samples
- [x] Added any applicable tests
