### PR TITLE
fix: prevent misleading afterAll failure when driver initialization fails

### DIFF
--- a/typescript-selenium-webdriver/tests/index.test.ts
+++ b/typescript-selenium-webdriver/tests/index.test.ts
@@ -34,7 +34,7 @@ describe('index.html', () => {
     }, TEST_TIMEOUT_MS);
 
     afterAll(async () => {
-        await driver.quit();
+        driver && await driver.quit();
     }, TEST_TIMEOUT_MS);
 
     beforeEach(async () => {


### PR DESCRIPTION
#### Description of changes

Previously, if the webdriver initialization step in `beforeAll` failed, it would result in `driver` never being set and a spurious failure in `afterAll` attempting to call `driver.quit()` for undefined `driver`. This adds a defensive check to prevent the spurious secondary error message.

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: Partially addresses #37 
- [x] `yarn test` passes in all affected samples
- [x] Added any applicable tests
