### PR TITLE
docs: fix broken link to SampleTest.cs in README

### DIFF
--- a/csharp-selenium-webdriver-sample/README.md
+++ b/csharp-selenium-webdriver-sample/README.md
@@ -8,7 +8,7 @@ The individual files in the sample contain comments that explain the important p
 
 Some good places to start reading are:
 
-* [tests/SampleTest.cs](./tests/SampleTest.cs): C# test file that opens [SamplePage.html](./SamplePage.html) in a browser with Selenium and runs accessibility scans against it with Selenium.WebDriver.ChromeDriver and Selenium.WebDriver.GeckoDriver
+* [SampleTest.cs](./SampleTest.cs): C# test file that opens [SamplePage.html](./SamplePage.html) in a browser with Selenium and runs accessibility scans against it with Selenium.WebDriver.ChromeDriver and Selenium.WebDriver.GeckoDriver
 * [azure-pipelines.yml](./azure-pipelines.yml): Azure Pipelines config file that sets up our Continuous Integration and Pull Request builds
 
 ## Tools and libraries used


### PR DESCRIPTION
#### Description of changes

Missed updating link to file when we flattened the directory structure.

#### Pull request checklist

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] `yarn test` passes in all affected samples
- [n/a] Added any applicable tests
