### PR TITLE
chore: standardize azure-pipelines.yml format with each other and per official docs

### DIFF
--- a/csharp-selenium-webdriver-sample/azure-pipelines.yml
+++ b/csharp-selenium-webdriver-sample/azure-pipelines.yml
@@ -2,25 +2,26 @@
 # Licensed under the MIT License.
 
 pool:
-    vmImage: windows-2019
+  vmImage: windows-2019
 
 variables:
   projectDirectory: '$(System.DefaultWorkingDirectory)/csharp-selenium-webdriver-sample'
 
 steps:
-- task: DotNetCoreInstaller@1
-  inputs:
-    version: '2.2.401'
+  - task: DotNetCoreInstaller@1
+    displayName: install .NET Core SDK 2.2.401
+    inputs:
+      version: '2.2.401'
 
-- script: dotnet test --logger:trx
-  displayName: dotnet test
-  workingDirectory: $(projectDirectory)
+  - script: dotnet test --logger:trx
+    displayName: dotnet test
+    workingDirectory: $(projectDirectory)
 
-- task: PublishTestResults@2
-  displayName: publish test results
-  inputs:
+  - task: PublishTestResults@2
+    displayName: publish test results
+    inputs:
       testResultsFiles: '**/TestResults/*.trx'
       testResultsFormat: VSTest
       searchFolder: $(projectDirectory)
       testRunTitle: dotnet test
-  condition: succeededOrFailed()
+    condition: succeededOrFailed()

--- a/typescript-selenium-webdriver-sample/azure-pipelines.yml
+++ b/typescript-selenium-webdriver-sample/azure-pipelines.yml
@@ -28,64 +28,67 @@
 # * https://docs.microsoft.com/en-us/azure/devops/pipelines/customize-pipeline
 
 pool:
-    # The 'windows-2019' and 'vs20xx-windows' vmImages come pre-installed with selenium drivers for common browsers.
-    # To use most other vmImages, you'll need to add a step to install these before running yarn test.
-    # See https://docs.microsoft.com/en-us/azure/devops/pipelines/test/continuous-test-selenium
-    vmImage: 'windows-2019'
+  # The 'windows-2019' and 'vs20xx-windows' vmImages come pre-installed with selenium drivers for common browsers.
+  # To use most other vmImages, you'll need to add a step to install these before running yarn test.
+  # See https://docs.microsoft.com/en-us/azure/devops/pipelines/test/continuous-test-selenium
+  vmImage: 'windows-2019'
 
 steps:
-    # This task makes sure Node.js is installed on the build agent.
-    #
-    # It is a good idea to test against a specific, known version of Node; this makes it easier for other users
-    # to reproduce your build results.
-    - task: NodeTool@0
-      inputs:
-          versionSpec: '10.15.3'
-      displayName: install node 10.15.3
+  # This task makes sure Node.js is installed on the build agent.
+  #
+  # It is a good idea to test against a specific, known version of Node; this makes it easier for other users
+  # to reproduce your build results.
+  - task: NodeTool@0
+    displayName: install node 10.15.3
+    inputs:
+      versionSpec: '10.15.3'
 
-    # This task installs dependencies specified in your package.json file.
-    #
-    # Our sample uses Yarn for this, but if your project uses NPM instead, that's also fine.
-    #
-    # Note that we add a specific command line option here to tell the "chromedriver" package to
-    # use the preinstalled version of the Chrome webdriver that matches the preinstalled version of
-    # Chrome on the hosted Microsoft build agent. The build agent comes with a "ChromeWebDriver"
-    # environment variable pre-set to the location of the preinstalled chromedriver.exe. You would
-    # typically omit this argument when running "yarn install" locally, since most users won't have
-    # chromedriver preinstalled like the build agent will.
-    - script: yarn install --frozen-lockfile --chromedriver_filepath=$(ChromeWebDriver) # or "npm install --ci"
-      # workingDirectory should match where your package.json file is located. It defaults to the root of the repository.
-      workingDirectory: $(Build.SourcesDirectory)/typescript-selenium-webdriver-sample
-      displayName: install dependencies
+  # This task installs dependencies specified in your package.json file.
+  #
+  # Our sample uses Yarn for this, but if your project uses NPM instead, that's also fine.
+  #
+  # Note that we add a specific command line option here to tell the "chromedriver" package to
+  # use the preinstalled version of the Chrome webdriver that matches the preinstalled version of
+  # Chrome on the hosted Microsoft build agent. The build agent comes with a "ChromeWebDriver"
+  # environment variable pre-set to the location of the preinstalled chromedriver.exe. You would
+  # typically omit this argument when running "yarn install" locally, since most users won't have
+  # chromedriver preinstalled like the build agent will.
+  - script: yarn install --frozen-lockfile --chromedriver_filepath=$(ChromeWebDriver) # or "npm install --ci"
+    displayName: yarn install
+    # workingDirectory should match where your package.json file is located. It defaults to the root of the repository.
+    workingDirectory: $(Build.SourcesDirectory)/typescript-selenium-webdriver-sample
 
-    # This tasks runs the tests specified by jest.config.js, including our example accessibility tests.
-    #
-    # If your project already uses npm instead of yarn, or if your project already runs "jest" directly here,
-    # those are both fine.
-    #
-    # The 2>&1 is a workaround for facebook/jest#5064
-    - script: yarn test --ci 2>&1 # or "npm run test -- --ci 2>&1", or "jest --ci 2>&1"
-      workingDirectory: $(Build.SourcesDirectory)/typescript-selenium-webdriver-sample
-      displayName: run tests
+  # This tasks runs the tests specified by jest.config.js, including our example accessibility tests.
+  #
+  # If your project already uses npm instead of yarn, or if your project already runs "jest" directly here,
+  # those are both fine.
+  #
+  # The 2>&1 is a workaround for facebook/jest#5064
+  - script: yarn test --ci 2>&1 # or "npm run test -- --ci 2>&1", or "jest --ci 2>&1"
+    displayName: yarn test
+    workingDirectory: $(Build.SourcesDirectory)/typescript-selenium-webdriver-sample
+    
 
-    # This task is how the "Tests" tab in our Azure Pipelines build results page gets its data
-    - task: PublishTestResults@2
-      inputs:
-          testResultsFiles: $(Build.SourcesDirectory)/typescript-selenium-webdriver-sample/test-results/junit.xml
-          testRunTitle: typescript-selenium-webdriver-sample
-      condition: always()
-      displayName: publish test results
+  # This task is how the "Tests" tab in our Azure Pipelines build results page gets its data
+  - task: PublishTestResults@2
+    displayName: publish test results
+    inputs:
+      testResultsFiles: $(Build.SourcesDirectory)/typescript-selenium-webdriver-sample/test-results/junit.xml
+      testRunTitle: typescript-selenium-webdriver-sample
+    condition: succeededOrFailed()
 
-    # If you are adding tests to an existing project that already uses Azure Pipelines, this is probably the only
-    # new task you'll need to add.
-    #
-    # This task is how the "Scans" tab in our Azure Pipelines build results page gets its data
-    - task: PublishBuildArtifacts@1
-      inputs:
-          # The exact name "CodeAnalysisLogs" is required for the Sarif Results Viewer Extension for Azure Pipelines
-          # to find the .sarif files our accessibility test produces.
-          artifactName: 'CodeAnalysisLogs'
-          # "test-results" is not a required convention; it just happens to be where our tests write .sarif files to.
-          pathtoPublish: '$(Build.SourcesDirectory)/typescript-selenium-webdriver-sample/test-results'
-      condition: always()
-      displayName: publish sarif results
+
+  # If you are adding tests to an existing project that already uses Azure Pipelines, this is probably the only
+  # new task you'll need to add.
+  #
+  # This task is how the "Scans" tab in our Azure Pipelines build results page gets its data
+  - task: PublishBuildArtifacts@1
+    displayName: publish sarif results
+    inputs:
+      # The exact name "CodeAnalysisLogs" is required for the Sarif Results Viewer Extension for Azure Pipelines
+      # to find the .sarif files our accessibility test produces.
+      artifactName: 'CodeAnalysisLogs'
+      # "test-results" is not a required convention; it just happens to be where our tests write .sarif files to.
+      pathtoPublish: '$(Build.SourcesDirectory)/typescript-selenium-webdriver-sample/test-results'
+    condition: succeededOrFailed()
+


### PR DESCRIPTION
#### Description of changes

Standardizes a few inconsistencies between our sample azure-pipelines.yml files and the official docs' samples:

* Use 2-space indentation throughout
* Put `displayName` in a consistent spot in steps
* Use consistent `displayName` formats between the 2 files
* Use `succeededOrFailed()` rather than `always()` for conditions on test publishing steps

#### Pull request checklist

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] `yarn test` passes in all affected samples
- [n/a] Added any applicable tests
