### PR TITLE
chore: use general codeowners team instead of web one

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners for everything in the repository.
-*   @microsoft/accessibility-insights-web-code-owners
+*   @microsoft/accessibility-insights-code-owners


### PR DESCRIPTION
#### Description of changes

Just noticed that Ortiga's approval in #56 wasn't being accepted because we've got the wrong team set up as code owners. Updating to use the more general team.

#### Pull request checklist

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] `yarn test` passes in all affected samples
- [n/a] Added any applicable tests
