### PR TITLE
chore: add Dependabot config file

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,3 +8,4 @@ update_configs:
   - package_manager: "javascript"
     directory: "/typescript-selenium-webdriver-sample"
     update_schedule: live
+    version_requirement_updates: increase_versions

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+
+update_configs:
+  - package_manager: "dotnet:nuget"
+    directory: "/csharp-selenium-webdriver-sample"
+
+  - package_manager: "javascript"
+    directory: "/typescript-selenium-webdriver-sample"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,6 +3,8 @@ version: 1
 update_configs:
   - package_manager: "dotnet:nuget"
     directory: "/csharp-selenium-webdriver-sample"
+    update_schedule: live
 
   - package_manager: "javascript"
     directory: "/typescript-selenium-webdriver-sample"
+    update_schedule: live


### PR DESCRIPTION
#### Description of changes

This repo has multiple "root" folders with different languages, so it requires a checked in config file for Dependabot to work correctly.

For docs on this config file, see https://dependabot.com/docs/config-file

I think the only particularly interesting/subjective part of this config is the `version_requirement_updates: increase_versions` on the typescript folder. Essentially, we have to decide whether Dependabot should update package.json in the way it normally would for a library (where it would update yarn.lock but widen version ranges in package.json) or the way it normally would for an app (where it updates package.json to require the newer version). I think the latter makes more sense for a sample but could probably be persuaded otherwise.

I've already run this through the [Dependabot config validator](https://dependabot.com/docs/config-file/validator/)

#### Pull request checklist

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] `yarn test` passes in all affected samples
- [n/a] Added any applicable tests
