### PR TITLE
Bump MSTest.* to 2.0.0

### DIFF
--- a/csharp-selenium-webdriver-sample/CSharpSeleniumWebdriverSample.csproj
+++ b/csharp-selenium-webdriver-sample/CSharpSeleniumWebdriverSample.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="Selenium.Axe" Version="1.2.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="76.0.3809.12600" />
     <PackageReference Include="Selenium.WebDriver.GeckoDriver" Version="0.24.0.1" />


### PR DESCRIPTION
#### Description of changes

Updates both MSTest dependencies in sync with one another to avoid them complaining about mismatching on the breaking 2.0.0 changes.

#### Pull request checklist

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [x] `yarn test` passes in all affected samples
- [n/a] Added any applicable tests
