### PR TITLE
[c#] Address user study feedback in SampleTests.cs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,6 @@
 #### Pull request checklist
 
 - [ ] If this PR addresses an existing issue, it is linked: Fixes #0000
-- [ ] `yarn test` passes in all affected samples
-- [ ] Added any applicable tests
+- [ ] New sample content is commented at a similar verbosity as existing content
+- [ ] All updated/modified sample code builds and runs in at least one PR/CI build
+- [ ] PR checks for builds named `[failing example] ...` fail as expected

--- a/csharp-selenium-webdriver-sample/README.md
+++ b/csharp-selenium-webdriver-sample/README.md
@@ -30,22 +30,6 @@ This sample also uses a few other tools and libraries which are less important; 
 * [FluentAssertions](https://fluentassertions.com/) to write test assertions
   * We like FluentAssertions because it gives great error messages out-of-the-box with Selenium.Axe. But you can still follow the rest of the sample if you prefer a different assertion style!
 
-## See it in action in Azure Pipelines
-
-[![Build Status](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_apis/build/status/csharp-selenium-webdriver-sample%20CI?branchName=master)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/latest?definitionId=30&branchName=master)
-
-<!--
-  Note to maintainers: The below example images/links come from a specific build instead of the most recent build so we can link to specific tabs.
-  If you update the links such that they point to a different build, make sure to mark that build as Retained so the links don't expire in a month.
--->
-The accessibility tests run as part of the `dotnet test` build step:
-
-[![Screenshot of "dotnet test" build logs in sample build](./Resources/screenshot-logs-tab.png)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/results?buildId=2338&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9)
-
-The test pass/fail results display in the Tests tab of the build logs:
-
-[![Screenshot of Tests tab in sample build](./Resources/screenshot-tests-tab.png)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/results?buildId=2338&view=ms.vss-test-web.build-test-results-tab&runId=6512&resultId=100000&paneView=debug)
-
 ## See it in action on your local machine
 
 1. Install the [.NET Core SDK](https://dotnet.microsoft.com/download)
@@ -65,3 +49,20 @@ The test pass/fail results display in the Tests tab of the build logs:
    ```
 
    ![Screenshot of 'dotnet test' command showing all tests passing](./Resources/screenshot-dotnet-test-success.png)
+
+## See it in action in Azure Pipelines
+
+* Example build with failures: [![Azure Pipelines Build Status for failing example build](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_apis/build/status/%5Bfailing%20example%5D%20csharp-selenium-webdriver-sample?branchName=master)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/latest?definitionId=33&branchName=master)
+* Example build without failures: [![Azure Pipelines Build Status for passing example build](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_apis/build/status/%5Bpassing%20example%5D%20csharp-selenium-webdriver-sample?branchName=master)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/latest?definitionId=32&branchName=master)
+
+<!--
+  Note to maintainers: The below example images/links come from a specific build instead of the most recent build so we can link to specific tabs.
+  If you update the links such that they point to a different build, make sure to mark that build as Retained so the links don't expire in a month.
+-->
+The accessibility tests run as part of the `dotnet test` build step:
+
+[![Screenshot of "dotnet test" build logs in sample build](./Resources/screenshot-logs-tab.png)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/results?buildId=2338&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9)
+
+The test pass/fail results display in the Tests tab of the build logs:
+
+[![Screenshot of Tests tab in sample build](./Resources/screenshot-tests-tab.png)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/results?buildId=2338&view=ms.vss-test-web.build-test-results-tab&runId=6512&resultId=100000&paneView=debug)

--- a/csharp-selenium-webdriver-sample/SamplePage.html
+++ b/csharp-selenium-webdriver-sample/SamplePage.html
@@ -6,8 +6,13 @@
 <body>
     <main>
         <h1>This is a static sample page with some accessibility issues</h1>
-        <p id="example-accessible-element">There's nothing wrong with this paragraph!</p>
-        <ul id="example-accessibility-violations">
+        <h2>Here are some examples of content without axe-core violations</h2>
+        <p id="id-of-example-accessible-element">There's nothing wrong with this paragraph!</p>
+        <p class="class-of-example-accessible-element">There's also nothing wrong with this paragraph!</p>
+        <iframe id="id-of-iframe" title="example of an iframe" srcdoc="&lt;p id='id-of-element-inside-iframe'>Nothing wrong here either!&lt;/p>"></iframe>
+
+        <h2>Here are some examples of content with different types of axe-core violations</h2>
+        <ul id="id-of-example-accessibility-violation-list">
             <li>This input box lacks an accessible label, which violates wcag2a rule "label": <input id="example-wcag2a-violation" type="text"></li>
             <li>This text's color contrast is too low, which violates wcag2aa rule "color-contrast": <span id="example-wcag2aa-violation" style="color: #A2A2A2">low-contrast text</span></li>
             <li>This button uses a tabindex greater than 0, which violates best-practice rule "tabindex": <button id="example-best-practice-violation" tabindex="1">button with high tabindex</button></li>

--- a/csharp-selenium-webdriver-sample/SamplePageTests.cs
+++ b/csharp-selenium-webdriver-sample/SamplePageTests.cs
@@ -82,8 +82,8 @@ namespace CSharpSeleniumWebdriverSample
         // match a particular tag (axe-core uses tags to indicate whether a rule is a "best practice" vs a WCAG requirement).
         //
         // For complete documentation of which rule IDs and tags axe supports, see:
-        // * axe-core rules: https://dequeuniversity.com/rules/axe
-        // * axe-core tags: https://www.deque.com/axe/axe-for-web/documentation/api-documentation/#api-name-axegetrules
+        // * summary of rules with IDs and tags: https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md
+        // * full reference documentation for each rule: https://dequeuniversity.com/rules/axe
         [TestMethod]
         public void TestWithOnlyRulesRequiredByWCAG2AA()
         {
@@ -103,9 +103,9 @@ namespace CSharpSeleniumWebdriverSample
 
             // If you want to be even more granular, you can also use WithRules to scan just certain individual rules.
             //
-            // For a complete list of the available axe rules, see https://dequeuniversity.com/rules/axe. Each rule's
-            // documentation page will note the ID of that rule (like "audio-caption" or "image-alt") at the top of the page;
-            // that ID is the string you would want to pass to the WithRules() method.
+            // For a complete list of the rules, see:
+            // * https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md
+            // * https://dequeuniversity.com/rules/axe
             AxeResult imageAltResults = new AxeBuilder(_webDriver)
                 .WithRules("image-alt")
                 // Nothing on our test page violates the image-alt rule, so this scan won't flag any Violations either.

--- a/csharp-selenium-webdriver-sample/SamplePageTests.cs
+++ b/csharp-selenium-webdriver-sample/SamplePageTests.cs
@@ -25,6 +25,7 @@ namespace CSharpSeleniumWebdriverSample
 
         // This test case shows the most basic example: run an accessibility scan on a page and assert that there are no violations.
         [TestMethod]
+        [TestCategory("IntentionallyFailsAsAnExample")]
         public void TestAccessibilityOfPage()
         {
             AxeResult axeResult = new AxeBuilder(_webDriver).Analyze();

--- a/csharp-selenium-webdriver-sample/SamplePageTests.cs
+++ b/csharp-selenium-webdriver-sample/SamplePageTests.cs
@@ -1,12 +1,19 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OpenQA.Selenium;
+// This sample happens to use .NET Core, but you can use whichever .NET version makes sense for your project.
+// Everything we're demonstrating would also work in .NET Framework 4.5+ with no modifications.
 using System;
 using System.IO;
-using Selenium.Axe;
+// This sample happens to use MSTest, but you can use whichever test framework you like.
+// Everything we're demonstrating would also work with xUnit, NUnit, or any other test framework.
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+// If you're using Selenium already, you're probably already using these.
+using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
+// These are the important new libraries we're demonstrating.
+// You'll probably need to add new NuGet package references for these.
+using Selenium.Axe;
 using FluentAssertions;
 
 namespace CSharpSeleniumWebdriverSample
@@ -14,7 +21,139 @@ namespace CSharpSeleniumWebdriverSample
     [TestClass]
     public class SamplePageTests
     {
-        private static IWebDriver _webDriver;
+        #region Example test methods
+
+        // This test case shows the most basic example: run an accessibility scan on a page and assert that there are no violations.
+        [TestMethod]
+        public void TestAccessibilityOfPage()
+        {
+            AxeResult axeResult = new AxeBuilder(_webDriver).Analyze();
+
+            // axeResult.Violations is an array of all the accessibility violations the scan found; the easiest way to assert
+            // that a scan came back clean is to assert that the Violations array is empty. You can do this with the built in
+            // MSTest assertions like this:
+            //
+            //     Assert.AreEqual(0, axeResult.Violations.Length);
+            //
+            // However, we don't recommend using Assert.AreEqual for this because it doesn't give very useful error messages if
+            // it does detect a violation; the error message will just say "expected 0 but found 1".
+            //
+            // We recommend using FluentAssertions instead; its default behavior gives much better error messages that include
+            // full descriptions of accessibility issues, including links to detailed guidance at https://dequeuniversity.com
+            // and CSS selector paths that exactly identify the element on the page with the issue.
+            axeResult.Violations.Should().BeEmpty();
+        }
+
+        // This test case shows 2 options for scanning specific elements within a page, rather than an entire page.
+        [TestMethod]
+        public void TestAccessibilityOfIndividualElements()
+        {
+            // Both of these 2 options work equally well; which one to use is a matter of preference.
+
+            // Option 1: using Selenium's FindElement to identify the element to test
+            //
+            // This can be simpler if your test already had to find the element for earlier assertions, or if you want to test
+            // an element that is hard to identify using a CSS selector.
+            IWebElement elementUnderTest = _webDriver.FindElement(By.Id("id-of-example-accessible-element"));
+
+            AxeResult axeResultWithAnalyzeWebElement = new AxeBuilder(_webDriver).Analyze(elementUnderTest);
+
+            axeResultWithAnalyzeWebElement.Violations.Should().BeEmpty();
+
+            // Option 2: using AxeBuilder.Include
+            //
+            // This can be simpler if you need to test multiple elements at once or need to deal with <iframe>s.
+            AxeResult axeResultWithInclude = new AxeBuilder(_webDriver)
+                .Include("#id-of-example-accessible-element")
+                .Include(".class-of-example-accessible-element")
+                .Include("#id-of-iframe", "#id-of-element-inside-iframe")
+                .Analyze();
+
+            axeResultWithInclude.Violations.Should().BeEmpty();
+        }
+
+        // By default, an axe-core scan will check the page under test against a wide variety of different rules. Some of
+        // these rules correspond directly to the requirements of different accessibility standards documents (most notably
+        // the Web Content Accessibility Guidelines, WCAG); others are best practices, which are generally good ideas but
+        // might have allowable exceptions or might not map neatly to a WCAG requirement.
+        //
+        // This example shows how you would restrict an accessibility scan to only run against *some* of the rules axe-core
+        // provides. You can either specify specific rules to enable/disable, or you can use tags to run all of the rules that
+        // match a particular tag (axe-core uses tags to indicate whether a rule is a "best practice" vs a WCAG requirement).
+        //
+        // For complete documentation of which rule IDs and tags axe supports, see:
+        // * axe-core rules: https://dequeuniversity.com/rules/axe
+        // * axe-core tags: https://www.deque.com/axe/axe-for-web/documentation/api-documentation/#api-name-axegetrules
+        [TestMethod]
+        public void TestWithOnlyRulesRequiredByWCAG2AA()
+        {
+            // Axe uses tags to identify which rules are required by WCAG standards. The "wcag2a" tag covers all axe-core rules
+            // that correspond to WCAG 2.0 A success criteria, and the "wcag2aa" and "wcag21aa" tags cover those axe-core rules
+            // that correspond to WCAG 2.0 and 2.1 AA success criteria.
+            //
+            // If you wanted to run a scan against *only* those rules corresponding to WCAG 2.0/2.1 A and AA success criteria,
+            // omitting any best practice rules not directly applicable to a WCAG criteria, you could run a scan like this:
+            AxeResult wcagRequiredResults = new AxeBuilder(_webDriver)
+                .WithTags("wcag2a", "wcag2aa", "wcag21aa")
+                // The element we're analyzing only has a best-practice violation, not a WCAG violation, so this scan won't flag
+                // any Violations.
+                .Analyze(_webDriver.FindElement(By.Id("example-best-practice-violation")));
+
+            wcagRequiredResults.Violations.Should().BeEmpty();
+
+            // If you want to be even more granular, you can also use WithRules to scan just certain individual rules.
+            //
+            // For a complete list of the available axe rules, see https://dequeuniversity.com/rules/axe. Each rule's
+            // documentation page will note the ID of that rule (like "audio-caption" or "image-alt") at the top of the page;
+            // that ID is the string you would want to pass to the WithRules() method.
+            AxeResult imageAltResults = new AxeBuilder(_webDriver)
+                .WithRules("image-alt")
+                // Nothing on our test page violates the image-alt rule, so this scan won't flag any Violations either.
+                .Analyze();
+                
+            imageAltResults.Violations.Should().BeEmpty();
+        }
+
+        // This test case shows how you might baseline some known/pre-existing accessibility violations from your tests.
+        // This is useful when just getting started with accessibility testing, so you can prevent new issues from creeping in
+        // while you're still working on fixing any existing issues.
+        [TestMethod]
+        public void TestAccessibilityOfPageExcludingKnownIssues()
+        {
+            // You can use AxeBuilder.Exclude to exclude individual elements with known issues from a scan.
+            //
+            // Exclude accepts any CSS selector; you could also use ".some-classname" or "div[some-attr='some value']"
+            AxeResult axeResultExcludingExampleViolationsElement = new AxeBuilder(_webDriver)
+                .Exclude("#id-of-example-accessibility-violation-list")
+                .Analyze();
+            
+            axeResultExcludingExampleViolationsElement.Violations.Should().BeEmpty();
+
+            // You can also use AxeBuilder.DisableRules to exclude certain individual rules from a scan. This is particularly
+            // useful if you still want to perform *some* scanning on the elements you exclude from more broad scans.
+            AxeResult axeResultDisablingRulesViolatedByExamples = new AxeBuilder(_webDriver)
+                .Include("#id-of-example-accessibility-violation-list") // Like Exclude(), accepts any CSS selector
+                .DisableRules("color-contrast", "label", "tabindex")
+                .Analyze();
+
+            axeResultDisablingRulesViolatedByExamples.Violations.Should().BeEmpty();
+
+            // Another option is to assert on the size of the Violations array. This works just fine, but we recommend the
+            // other options above as your first choice instead because when they do find new issues, they will produce error
+            // messages that more clearly identify exactly what the new/unexpected issues are.
+            AxeResult axeResult = new AxeBuilder(_webDriver).Analyze();
+            axeResult.Violations.Should().HaveCount(3);
+        }
+
+        #endregion
+
+        #region Example setup and cleanup methods
+
+        // The rest of this file shows examples of how to set up an IWebDriver instance to connect to a browser and
+        // navigate to a test page.
+        //
+        // If you're incorporating accessibility testing into an existing body of end to end tests, you can stick with
+        // however your existing tests are already solving this; you don't need to do anything special to use Selenium.Axe.
 
         // Starting a new browser process is good for keeping tests isolated from one another, but can be slow. Here, we're
         // using a [ClassInitialize] method so the same browser will be shared between different [TestMethod]s.
@@ -60,81 +199,8 @@ namespace CSharpSeleniumWebdriverSample
                 .Until(d => d.FindElement(By.TagName("main")));
         }
 
-        // This test case shows the most basic example: run an accessibility scan on an element and assert that there are
-        // no violations.
-        [TestMethod]
-        public void TestAccessibilityOfSingleElement()
-        {
-            IWebElement elementUnderTest = _webDriver.FindElement(By.Id("example-accessible-element"));
+        private static IWebDriver _webDriver;
 
-            AxeResult axeResult = new AxeBuilder(_webDriver)
-                .Analyze(elementUnderTest);
-
-            // This is the simplest way to assert that the axe scan didn't find any violations. However, if it *does* find
-            // some violations, it doesn't give a very useful error message; it just says "expected 0 but found 1".
-            Assert.AreEqual(0, axeResult.Violations.Length);
-
-            // We recommend using FluentAssertions instead; its default behavior gives much better error messages that include
-            // full descriptions of accessibility issues, including links to detailed guidance at https://dequeuniversity.com
-            // and CSS selector paths that exactly identify the element on the page with the issue.
-            axeResult.Violations.Should().BeEmpty();
-        }
-
-        // This test case shows how to run just a subset of the available axe rules in an accessibility scan.
-        // This is useful when just getting started with accessibility testing; you can start with a small set of rules and
-        // expand to a more complete set of rules over time.
-        [TestMethod]
-        public void TestWCAGCompliance()
-        {
-            // Axe implements checks for many different "rules". Rules usually correspond to specific accessibility standards,
-            // like WCAG or Section 508, though some are "best-practice" rules that don't (yet) correspond to a recognized
-            // accessibility standard. By default, Axe runs *all* non-experimental rules.
-            //
-            // If you're adding checks to a page with many existing violations, you might start off with scanning for just the
-            // "WCAG A" rules, and later expand to include the "WCAG AA" rules, before finally starting to scan for *all*
-            // violations. You can do that with the WithTags method: 
-            AxeResult wcag2Results = new AxeBuilder(_webDriver)
-                .Include("#example-best-practice-violation") // not a WCAG violation
-                .WithTags("wcag2a", "wcag2aa")
-                .Analyze();
-
-            wcag2Results.Violations.Should().BeEmpty();
-
-            // If you want to be even more granular, you can also use WithRules to scan just certain individual rules:
-            AxeResult imageAltResults = new AxeBuilder(_webDriver)
-                .WithRules("image-alt")
-                .Analyze();
-                
-            imageAltResults.Violations.Should().BeEmpty();
-        }
-
-        // This test case shows how you might baseline some known/pre-existing accessibility violations from your tests.
-        // This is useful when just getting started with accessibility testing, so you can prevent new issues from creeping in
-        // while you're still working on fixing any existing issues.
-        [TestMethod]
-        public void TestAccessibilityOfPageExcludingKnownIssues()
-        {
-            // You can use AxeBuilder.Exclude to exclude individual elements with known issues from a scan.
-            AxeResult axeResultExcludingExampleViolationsElement = new AxeBuilder(_webDriver)
-                .Exclude("#example-accessibility-violations")
-                .Analyze();
-            
-            axeResultExcludingExampleViolationsElement.Violations.Should().BeEmpty();
-
-            // You can also use AxeBuilder.DisableRules to exclude certain individual rules from a scan. This is particularly
-            // useful if you still want to perform *some* scanning on the elements you exclude from more broad scans.
-            AxeResult axeResultDisablingRulesViolatedByExamples = new AxeBuilder(_webDriver)
-                .Include("#example-accessibility-violations")
-                .DisableRules("color-contrast", "label", "tabindex")
-                .Analyze();
-
-            axeResultDisablingRulesViolatedByExamples.Violations.Should().BeEmpty();
-
-            // Another option is to assert on the size of the Violations array. This works just fine, but we recommend the
-            // other options above as your first choice instead because when they do find new issues, they will produce error
-            // messages that more clearly identify exactly what the new/unexpected issues are.
-            AxeResult axeResult = new AxeBuilder(_webDriver).Analyze();
-            axeResult.Violations.Should().HaveCount(3);
-        }
+        #endregion
     }
 }

--- a/csharp-selenium-webdriver-sample/azure-pipelines.yml
+++ b/csharp-selenium-webdriver-sample/azure-pipelines.yml
@@ -74,3 +74,7 @@ steps:
       projects: $(Build.SourcesDirectory)/csharp-selenium-webdriver-sample/**/*.csproj
       publishTestResults: true
       testRunTitle: "dotnet test ($(imageName) $(browser))"
+      # We use this EXTRA_DOTNET_TEST_ARGUMENTS variable in the sample's CI/PR builds so the "success" examples can --filter
+      # out the tests that intentionally fail for example purposes. You probably don't need this in a real project.
+      arguments: $(EXTRA_DOTNET_TEST_ARGUMENTS)
+


### PR DESCRIPTION
#### Description of changes

Addresses a variety of feedback items received in the recent round of user studies for the C# sample. Specifically:

* Moves the test setup/cleanup below the example test methods
* Clarifies which `using` statements a reader is likely to care about
* Adds a TestMethod demonstrating a basic scan of an entire page as the first example test, before the "scan one element in page" example
* Ensures that there is an example test that actually fails in practice, to give a better idea of what a failure would look like
* Clarify how `Include` works before using it incidentally alongside `WithTags`
* Add a more precise/verbose description of what "tags" and "rules" are and how to find more information about them
* clarify that Include/Exclude accept CSS selectors (not just IDs)
* Update sample page element IDs to make it more obvious on first reading that they are, in fact, IDs
* Switches order of see it in action locally/in pipelines sections of README

The most interesting of these changes is adding a test case that shows an example of what failure looks like. I wanted to achieve a balance where doing this wouldn't lead a real user cloning the sample project to include infrastructure for this that they wouldn't normally want. To achieve this, I:
* Had the new "basic scan of the whole page" test (which fails naturally) be allowed to fail
* Gave it a `[TestCategory("IntentionallyFailsAsAnExample")]`
* Set up `azure-pipelines.yml` to pass through a queue-time `EXTRA_DOTNET_TEST_ARGUMENTS` parameter to the dotnet test command
* Cloned the pipelines configuration so we now have 2 PR/CI builds that run the same yml file
* Named one `[failing example]` using no extra dotnet test arguments, and named one `[passing example]` using an extra dotnet test argument of `--filter TestCategory!=IntentionallyFailsAsAnExample`

This way, if a user cloned the sample without reading any of the comments and reused stuff blindly, the most unnecessary extra bits they'd get are an unnecessary benign `[TestCategory]` in one test method and an unnecessary benign `arguments: EXTRA_DOTNET_TEST_ARGUMENTS` property in the configuration of the dotnet test task in their pipelines yml.

#### Pull request checklist

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [x] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` fail as expected
