### PR TITLE
chore: update issue templates to use comments for help text

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ## Describe the bug
 
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -20,7 +20,7 @@ Steps to reproduce the behavior:
 
 ## Expected behavior
 
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 ## Extension (please complete the following information)
 
@@ -30,12 +30,12 @@ A clear and concise description of what you expected to happen.
 
 ## Are you willing to submit a PR?
 
-If asked, will you be willing to submit a PR to fix this bug? Yes/No
+<!-- If asked, will you be willing to submit a PR to fix this bug? Yes/No -->
 
 ## Did you search for similar existing issues?
 
-Did you search for similar issues in our github issues or on stackoverflow for [azure-pipelines](https://stackoverflow.com/questions/tagged/azure-pipelines) and [accessibility](https://stackoverflow.com/questions/tagged/accessibility)?
+<!-- Did you search for similar issues in our GitHub issues or on StackOverflow for [azure-pipelines](https://stackoverflow.com/questions/tagged/azure-pipelines) and [accessibility](https://stackoverflow.com/questions/tagged/accessibility)? -->
 
 ## Additional context
 
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,13 +7,13 @@ assignees: ''
 ---
 
 ## Is your feature request related to a problem? Please describe.
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 ## Describe the desired outcome
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 ## Describe alternatives you've considered
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 ## Additional context
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/general_question.md
+++ b/.github/ISSUE_TEMPLATE/general_question.md
@@ -8,5 +8,7 @@ assignees: ''
 
 ## Your question here
 
+<!--
 Make sure to provide enough context. If you have spoken to a team member please mention them here.
 Add any items (screenshots etc) that will help.
+-->


### PR DESCRIPTION
#### Description of changes

Use comments for help text in issue templates so they don't show up when the issue creator doesn't delete them. The commented help text will still show up during issue creation.

#### Pull request checklist

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] New sample content is commented at a similar verbosity as existing content
- [n/a] All updated/modified sample code builds and runs in at least one PR/CI build
- [n/a] PR checks for builds named `[failing example] ...` fail as expected
