### PR TITLE
Set default window sizes

### DIFF
--- a/csharp-selenium-webdriver-sample/WebDriverFactory.cs
+++ b/csharp-selenium-webdriver-sample/WebDriverFactory.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using OpenQA.Selenium;
@@ -23,6 +23,13 @@ namespace CSharpSeleniumWebdriverSample
             // In our CI builds in Azure Pipelines, we'll always specify the browser explicitly instead of using this.
             const string DEFAULT_BROWSER = "chrome";
 
+            // Headless browsers generally use small window sizes by default. Some of the axe checks require
+            // elements to be present in the viewport to be assessable, so using a viewport size based on your
+            // most common usage is a good idea to prevent axe from having to do extra work to scroll items into
+            // view and avoid issues with elements not fitting into the viewport.
+            const int windowWidth = 1920;
+            const int windowHeight = 1080;
+
             switch (browserEnvVar ?? DEFAULT_BROWSER)
             {
                 case "chrome":
@@ -42,6 +49,7 @@ namespace CSharpSeleniumWebdriverSample
                     // because it makes it easier to run the tests in non-graphical environments (eg, most Docker containers)
                     var chromeOptions = new ChromeOptions();
                     chromeOptions.AddArgument("--headless");
+                    chromeOptions.AddArgument($"--window-size={windowWidth},{windowHeight}");
 
                     return new ChromeDriver(chromeDriverDirectory, chromeOptions);
 
@@ -52,7 +60,8 @@ namespace CSharpSeleniumWebdriverSample
                     // Same as for Chrome above; the tests will work fine without --headless, but you'll get better test
                     // performance and easier compatibility with non-graphical environments by using it.
                     var firefoxOptions = new FirefoxOptions();
-                    firefoxOptions.AddArgument("--headless");
+                    firefoxOptions.AddArgument("-headless");
+                    firefoxOptions.AddArguments("-width", $"{windowWidth}", "-height", $"{windowHeight}");
 
                     return new FirefoxDriver(geckoDriverDirectory, firefoxOptions);
 

--- a/typescript-selenium-webdriver-sample/tests/webdriver-factory.ts
+++ b/typescript-selenium-webdriver-sample/tests/webdriver-factory.ts
@@ -26,6 +26,12 @@ export function createWebdriverFromEnvironmentVariableSettings(): webdriver.Then
     const azurePipelinesAgentGeckoDriverPath = webdriverPathFromEnvVar('GeckoWebDriver', 'geckodriver.exe');
     const geckoDriverPath = azurePipelinesAgentGeckoDriverPath || require('geckodriver').path;
 
+    // Headless browsers generally use small window sizes by default. Some of the axe checks require
+    // elements to be present in the viewport to be assessable, so using a viewport size based on your
+    // most common usage is a good idea to prevent axe from having to do extra work to scroll items into
+    // view and avoid issues with elements not fitting into the viewport.
+    const windowSize = {width: 1920, height: 1080};
+
     return new webdriver.Builder()
         // forBrowser sets the *default* browser the tests will use. You can override the defaults
         // by setting the SELENIUM_BROWSER environment variable. This project's package.json includes
@@ -35,9 +41,9 @@ export function createWebdriverFromEnvironmentVariableSettings(): webdriver.Then
         // You can run accessibility scans on head-ful browsers, too; we recommend using headless
         // browsers unless your project strictly requires head-ful testing, since it will generally
         // be faster, more reliable, and easier to run in non-graphical environments (eg, Docker).
-        .setChromeOptions(new chrome.Options().headless())
+        .setChromeOptions(new chrome.Options().headless().windowSize(windowSize))
         .setFirefoxService(new firefox.ServiceBuilder(geckoDriverPath))
-        .setFirefoxOptions(new firefox.Options().headless())
+        .setFirefoxOptions(new firefox.Options().headless().windowSize(windowSize))
         .build();
 }
 


### PR DESCRIPTION
#### Description of changes

Per suggestion from @manishsat , this PR has the samples set a default window size explicitly, to avoid issues related to the color contrast test's "scroll into viewport" behavior in the default window sizes used by the browsers' headless modes (eg, https://github.com/dequelabs/axe-core/issues/1730)

I verified the syntax of the window size parameters locally by temporarily disabling the headless options and manually verifying the created window sizes.

#### Pull request checklist

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [x] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` fail as expected
