### PR TITLE
typescript sample: improve error message when running elevated

### DIFF
--- a/typescript-selenium-webdriver-sample/package.json
+++ b/typescript-selenium-webdriver-sample/package.json
@@ -12,6 +12,7 @@
         "chromedriver": "^79.0.0",
         "cross-env": "^6.0.3",
         "geckodriver": "^1.19.1",
+        "is-elevated": "^3.0.0",
         "jest": "^24.9.0",
         "jest-circus": "^24.9.0",
         "jest-junit": "^10.0.0",

--- a/typescript-selenium-webdriver-sample/tests/index.test.ts
+++ b/typescript-selenium-webdriver-sample/tests/index.test.ts
@@ -5,7 +5,7 @@ import { convertAxeToSarif } from 'axe-sarif-converter';
 import * as AxeWebdriverjs from 'axe-webdriverjs';
 import * as fs from 'fs';
 import * as path from 'path';
-import { By, ThenableWebDriver, until } from 'selenium-webdriver';
+import { By, WebDriver, until } from 'selenium-webdriver';
 import { promisify } from 'util';
 import { createWebdriverFromEnvironmentVariableSettings } from './webdriver-factory';
 
@@ -13,7 +13,7 @@ import { createWebdriverFromEnvironmentVariableSettings } from './webdriver-fact
 const TEST_TIMEOUT_MS = 30000;
 
 describe('index.html', () => {
-    let driver: ThenableWebDriver;
+    let driver: WebDriver;
 
     // Starting a browser instance is time-consuming, so we share one browser instance between
     // all tests in the file (by initializing it in beforeAll rather than beforeEach)
@@ -24,7 +24,7 @@ describe('index.html', () => {
         // global "browser" variable, like this:
         //
         //     driver = browser.webdriver;
-        driver = createWebdriverFromEnvironmentVariableSettings();
+        driver = await createWebdriverFromEnvironmentVariableSettings();
     }, TEST_TIMEOUT_MS);
 
     afterAll(async () => {

--- a/typescript-selenium-webdriver-sample/yarn.lock
+++ b/typescript-selenium-webdriver-sample/yarn.lock
@@ -1776,6 +1776,13 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-admin@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-admin/-/is-admin-3.0.0.tgz#5c6077fd235e056c3dbc0b6f1bbd23ff96e97135"
+  integrity sha512-wOa3CXFJAu8BZ2BDtG9xYOOrsq6oiSvc2jFPy4X/HINx5bmJUcW8e+apItVbU2E7GIfBVaFVO7Zit4oAWtTJcw==
+  dependencies:
+    execa "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -1834,6 +1841,14 @@ is-descriptor@^1.0.0, is-descriptor@^1.0.2:
     is-accessor-descriptor "^1.0.0"
     is-data-descriptor "^1.0.0"
     kind-of "^6.0.2"
+
+is-elevated@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-elevated/-/is-elevated-3.0.0.tgz#f0de684f89b5144179ae1729ba8af590b8e0cecb"
+  integrity sha512-wjcp6RkouU9jpg55zERl+BglvV5j4jx5c/EMvQ+d12j/+nIEenNWPu+qc0tCg3JkLodbKZMg1qhJzEwG4qjclg==
+  dependencies:
+    is-admin "^3.0.0"
+    is-root "^2.1.0"
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -1923,6 +1938,11 @@ is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
   integrity sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=
+
+is-root@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.1.0.tgz#809e18129cf1129644302a4f8544035d51984a9c"
+  integrity sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==
 
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
#### Description of changes

This PR is very much a "best of several bad options" scenario.

In #163, a user described a confusing error they got when attempting to run the sample on Windows in an elevated command prompt (`WebDriverError: unknown error: unable to discover open pages`). 

There are many StackOverflow/crbug posts regarding this error message (the message is very generic; it generally indicates that ChromeDriver thinks it was able to launch a Chrome instance but not communicate with it after launch). In general, the issue is that Chrome's default sandboxing prevents communication between ChromeDriver and an elevated Chrome instance. I was unable to find any options for resolving this besides "disable Chrome's sandboxing". I don't think that's an appropriate option for our sample to recommend, so I instead went with the approach of detecting this case explicitly and emitting a better warning message, which in practice looks like this on a console:

```
  ● index.html › has only accessibility issues stored in our snapshot corresponding to only wcag2a and wcag2aa rules


                You are running from an elevated (root/admin) context.
                Chrome's sandboxing prevents communication with Selenium in this configuration.
                Try again from an un-elevated context.

      44 |     // offer a more understandable error message to contributors that might make a mistake.
      45 |     if (await isElevated()) {
    > 46 |         throw new Error(`
         |               ^
      47 |             You are running from an elevated (root/admin) context.
      48 |             Chrome's sandboxing prevents communication with Selenium in this configuration.
      49 |             Try again from an un-elevated context.


      at Object.<anonymous> (tests/webdriver-factory.ts:46:15)
      at step (tests/webdriver-factory.ts:33:23)
      at Object.next (tests/webdriver-factory.ts:14:53)
      at fulfilled (tests/webdriver-factory.ts:5:58)
```

I added a dependency (`is-elevated`) to perform the check; I'm not thrilled about adding a questionably-necessary dependency to sample code, but I didn't want to rely on catching the error message from ChromeDriver (it's too generic), and it [turns out to be surprisingly complicated](https://stackoverflow.com/questions/4051883/batch-script-how-to-check-for-admin-rights) to reliably detect this on Windows, and I didn't want to add that complication to the sample code directly.

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: Fixes #163 
- [x] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` fail as expected
