### PR TITLE
feat(axe-core-4.0.2): update from axe-webdriverjs to @axe-core/webdriverjs

### DIFF
--- a/typescript-selenium-webdriver-sample/README.md
+++ b/typescript-selenium-webdriver-sample/README.md
@@ -2,12 +2,13 @@
 
 This sample demonstrates how you might set up a CI build for a simple, static html page to perform end to end accessibility tests in a browser, including how to suppress pre-existing or third-party failures using [Jest Snapshot Testing](https://jestjs.io/docs/en/snapshot-testing). 
 
-This sample uses Selenium WebDriver for browser automation and uses the corresponding axe-webdriverjs library to integrate Axe and Selenium. But you don't have to use Selenium to use Axe! If you prefer a different browser automation tool, you can still follow the same concepts from this sample by using the integration library appropriate for your framework:
+This sample uses Selenium WebDriver for browser automation and uses the corresponding `@axe-core/webdriverjs` library to integrate Axe and Selenium. But you don't have to use Selenium to use Axe! If you prefer a different browser automation tool, you can still follow the same concepts from this sample by using the integration library appropriate for your framework:
 
-* For **Puppeteer**, use [axe-puppeteer](https://www.npmjs.com/package/axe-puppeteer)
+* For **Puppeteer**, use [@axe-core/puppeteer](https://www.npmjs.com/package/@axe-core/puppeteer)
+* For **Playwright**, use [axe-playwright](https://www.npmjs.com/package/axe-playwright)
 * For **Cypress**, use [cypress-axe](https://www.npmjs.com/package/cypress-axe)
-* For **WebdriverIO**, use [axe-webdriverio](https://www.npmjs.com/package/axe-webdriverio)
-* For **Protractor**, keep using axe-webdriverjs like the sample shows, but instead of creating your own Webdriver object, pass [`browser.webdriver`](https://www.protractortest.org/#/api?view=ProtractorBrowser) to axe-webdriverjs.
+* For **WebdriverIO**, use [@axe-core/webdriverio](https://www.npmjs.com/package/@axe-core/webdriverio)
+* For **Protractor**, keep using `@axe-core/webdriverjs` like the sample shows, but instead of creating your own Webdriver object, pass [`browser.webdriver`](https://www.protractortest.org/#/api?view=ProtractorBrowser) to `@axe-core/webdriverjs`.
 
 ## Getting Started
 
@@ -15,7 +16,7 @@ The individual files in the sample contain comments that explain the important p
 
 Some good places to start reading are:
 
-* [tests/index.test.ts](./tests/index.test.ts): Jest test file that opens [src/index.html](./src/index.html) in a browser with Selenium and runs accessibility scans against it with axe-webdriverjs
+* [tests/index.test.ts](./tests/index.test.ts): Jest test file that opens [src/index.html](./src/index.html) in a browser with Selenium and runs accessibility scans against it with `@axe-core/webdriverjs`
 * [azure-pipelines.yml](./azure-pipelines.yml): Azure Pipelines config file that sets up our Continuous Integration and Pull Request builds
 * [jest.config.js](./jest.config.js): Jest configuration file that enables TypeScript (using ts-jest) and test result reporting in Azure Pipelines (using jest-junit)
 
@@ -25,7 +26,7 @@ Some good places to start reading are:
 * [Jest](https://jestjs.io/) as our test framework, with [Jest Snapshot Testing](https://jestjs.io/docs/en/snapshot-testing) for baselining and [ts-jest](https://www.npmjs.com/package/ts-jest) for TypeScript support
 * [selenium-webdriver](https://www.npmjs.com/package/selenium-webdriver) to automate browsing to the page from the tests
 * [node-chromedriver](https://github.com/giggio/node-chromedriver) to enable Selenium to drive Chrome
-* [axe-webdriverjs](https://github.com/dequelabs/axe-webdriverjs) to run an axe accessibility scan on the page from the Selenium browser
+* [@axe-core/webdriverjs](https://github.com/dequelabs/axe-core-npm/tree/develop/packages/webdriverjs) to run an axe accessibility scan on the page from the Selenium browser
 * [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) to run the tests in a CI build with every Pull Request
 * [axe-sarif-converter](https://github.com/microsoft/axe-sarif-converter) to convert axe results to SARIF format
 * [Sarif Viewer Build Tab](https://marketplace.visualstudio.com/items?itemName=sariftools.sarif-viewer-build-tab) to visualize the results in Azure Pipelines

--- a/typescript-selenium-webdriver-sample/package.json
+++ b/typescript-selenium-webdriver-sample/package.json
@@ -1,14 +1,14 @@
 {
     "name": "typescript-selenium-webdriver-sample",
     "version": "0.0.0",
-    "description": "Sample project that demonstrates accessibility testing with TypeScript, Jest, Selenium, axe-webdriver, SARIF, and Azure Pipelines.",
+    "description": "Sample project that demonstrates accessibility testing with TypeScript, Jest, Selenium, @axe-core/webdriverjs, SARIF, and Azure Pipelines.",
     "private": true,
     "devDependencies": {
+        "@axe-core/webdriverjs": "^4.0.0",
         "@types/jest": "^26.0.14",
         "@types/node": "^14.11.2",
         "@types/selenium-webdriver": "^4.0.9",
         "axe-sarif-converter": "^2.5.1",
-        "axe-webdriverjs": "^2.3.0",
         "chromedriver": "^85.0.1",
         "cross-env": "^7.0.2",
         "geckodriver": "^1.20.0",

--- a/typescript-selenium-webdriver-sample/tests/index.test.ts
+++ b/typescript-selenium-webdriver-sample/tests/index.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as Axe from 'axe-core';
 import { convertAxeToSarif } from 'axe-sarif-converter';
-import * as AxeWebdriverjs from 'axe-webdriverjs';
+import AxeWebdriverjs from '@axe-core/webdriverjs';
 import * as fs from 'fs';
 import * as path from 'path';
 import { By, ThenableWebDriver, until } from 'selenium-webdriver';
@@ -51,7 +51,7 @@ describe('index.html', () => {
     // This test case shows the most basic example: run a scan, fail the test if there are any failures.
     // This is the way to go if you have no known/pre-existing violations you need to temporarily baseline.
     it('has no accessibility violations in the h1 element', async () => {
-        const accessibilityScanResults = await AxeWebdriverjs(driver)
+        const accessibilityScanResults = await new AxeWebdriverjs(driver)
             // You can use any CSS selector in place of "h1" here
             .include('h1')
             // This withTags directive restricts Axe to only run tests that detect known violations of
@@ -70,7 +70,7 @@ describe('index.html', () => {
     // component you don't control fixing yourself), you can exclude it specifically and still scan the rest
     // of the page.
     it('has no accessibility violations outside of the known example violations', async () => {
-        const accessibilityScanResults = await AxeWebdriverjs(driver)
+        const accessibilityScanResults = await new AxeWebdriverjs(driver)
             .exclude('#example-accessibility-violations')
             .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
             .analyze();
@@ -83,7 +83,7 @@ describe('index.html', () => {
     // If you want to more precisely baseline a particular set of known issues, one option is to use Jest
     // Snapshot Testing (https://jestjs.io/docs/snapshot-testing) with the scan results object.
     it('has only those accessibility violations present in snapshot', async () => {
-        const accessibilityScanResults = await AxeWebdriverjs(driver)
+        const accessibilityScanResults = await new AxeWebdriverjs(driver)
             .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
             .analyze();
 

--- a/typescript-selenium-webdriver-sample/yarn.lock
+++ b/typescript-selenium-webdriver-sample/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@axe-core/webdriverjs@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@axe-core/webdriverjs/-/webdriverjs-4.0.0.tgz#4e8a6ad6f2c065ce9018e16a40454ec680c27bf2"
+  integrity sha512-zDlA9xpwVJKeWStOQQkIxAzNF3bnbrN5y7UkjsBZdibRUruldrsUmngiW4qrpAKRVxkGkME1ykgjNizhpDurog==
+  dependencies:
+    axe-core "^4.0.1"
+    babel-runtime "^6.26.0"
+
 "@babel/code-frame@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
@@ -1026,10 +1034,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.1.tgz#e337c2ed1e6fe73920166d8b0b0b352e1b50d8ae"
   integrity sha512-OSCABHvSNDleKqJP7DUwEBvMVbr/gtOj2vCDoKKz967fxe9WqtCZLo3IRNOO2fJcu+eSFsu8aAToHfIY7sPLaw==
 
-axe-core@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.3.1.tgz#3d1fa78cca8ead1b78c350581501e4e37b97b826"
-  integrity sha512-gw1T0JptHPF4AdLLqE8yQq3Z7YvsYkpFmFWd84r6hnq/QoKRr8icYHFumhE7wYl5TVIHgVlchMyJsAYh0CfwCQ==
+axe-core@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.2.tgz#c7cf7378378a51fcd272d3c09668002a4990b1cb"
+  integrity sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==
 
 axe-sarif-converter@^2.5.1:
   version "2.5.1"
@@ -1039,15 +1047,6 @@ axe-sarif-converter@^2.5.1:
     "@types/sarif" ">=2.1.1 <=2.1.2"
     axe-core "^3.2.2 || ^4.0.0"
     yargs "^15.0.2"
-
-axe-webdriverjs@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/axe-webdriverjs/-/axe-webdriverjs-2.3.0.tgz#92511fbce38624a57e1aa861dd8a3c73c6a3a972"
-  integrity sha512-AuUsX5OFTXOJ6reIKjtGay4O656n5G+m8MzhfL1SC8MHINBFFFn3Taucckn8+UZYJuTtNEobllSfiuPTHyKnSA==
-  dependencies:
-    axe-core "^3.3.1"
-    babel-runtime "^6.26.0"
-    depd "^2.0.0"
 
 axios@^0.19.2:
   version "0.19.2"
@@ -1661,11 +1660,6 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
-
-depd@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
-  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 detect-newline@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
#### Description of changes

This updates the typescript sample to use the updated name for `@axe-core/webdriverjs` (as well as the related libraries we mention the names of in the README). There was one minor code change required as part of the update.

Note, this implicitly updates the version of axe-core in use to 4.0.2 (the sample gets it indirectly via the webdriverjs lib)

#### Pull request checklist

- [x] If this PR addresses an existing issue, it is linked: 1775951
- [x] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` fail as expected
