### PR TITLE
experimenting with Github App auth for pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Axe + Azure Pipelines: Automate accessibility testing in your CI builds
-
+test
 Watch a [short intro video](https://www.youtube.com/watch?v=SarmnCULt8M) to get started with automated accessibility tests in Azure pipelines. Please note that these samples are applicable to web projects that have UI automation tests. Benefits include,
 
 - Automated accessibility tests run during Continuous Integration and Pull Request builds, ensuring that all code changes are free of common easily-detected accessibility issues before they go to production

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Axe + Azure Pipelines: Automate accessibility testing in your CI builds
-test
+test2
 Watch a [short intro video](https://www.youtube.com/watch?v=SarmnCULt8M) to get started with automated accessibility tests in Azure pipelines. Please note that these samples are applicable to web projects that have UI automation tests. Benefits include,
 
 - Automated accessibility tests run during Continuous Integration and Pull Request builds, ensuring that all code changes are free of common easily-detected accessibility issues before they go to production


### PR DESCRIPTION
This PR is not meant to be merged - I'm testing some build changes. Before this PR I tried [these instructions](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#how-do-i-switch-my-pipeline-to-use-github-app-instead-of-oauth) to switch to Github app authentication for our pipelines.

This didn't work because multiple ADO organizations are linked to this GitHub repo, but:

> If a different Azure DevOps organization is reported, then someone has already established a pipeline for this repo in a different organization. We currently have the limitation that we can only map a GitHub repo to a single DevOps org. Only the pipelines in the first Azure DevOps org can be automatically triggered. To change the mapping, uninstall the app from the GitHub organization, and re-install it. As you re-install it, make sure to select the correct organization when you are redirected to Azure DevOps.

Unless this limitation is lifted or the orgs rely on different types of triggers, I don't think we'll be able to switch entirely to the Github app authentication just yet.