### PR TITLE
chore: add playwright sample to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,16 @@ updates:
   - dependency-name: "@types/node"
     versions:
     - ">=15.0.0"
+- package-ecosystem: npm
+  directory: "/typescript-playwright-sample"
+  schedule:
+    interval: daily
+    time: "11:00"
+    timezone: "America/Los_Angeles" # Pacific Time
+  versioning-strategy: increase
+  ignore:
+    # Major version of @types/node is pinned to match the version of node we
+    # use for builds (ideally, latest LTS)
+  - dependency-name: "@types/node"
+    versions:
+    - ">=15.0.0"


### PR DESCRIPTION
#### Details

I missed adding the new playwright sample to our dependabot config with #579 , this corrects the mistake

##### Motivation

Keep deps up to date

##### Context

see #579 

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] New sample content is commented at a similar verbosity as existing content
- [n/a] All updated/modified sample code builds and runs in at least one PR/CI build
- [ ] PR checks for builds named `[failing example] ...` fail as expected
