### PR TITLE
fix: correct accessibility spelling in READMEs

### DIFF
--- a/typescript-playwright-sample/README.md
+++ b/typescript-playwright-sample/README.md
@@ -45,7 +45,7 @@ The test pass/fail results display in the Tests tab of the build logs:
 
 [![Screenshot of Tests tab in sample build](./assets/screenshot-tests-tab.png)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/results?buildId=22505&view=ms.vss-test-web.build-test-results-tab)
 
-Detailed accessibliity scan information also appears in the Scans tab, courtesy of the [SARIF SAST Scans Tab extension](https://marketplace.visualstudio.com/items?itemName=sariftools.scans):
+Detailed accessibility scan information also appears in the Scans tab, courtesy of the [SARIF SAST Scans Tab extension](https://marketplace.visualstudio.com/items?itemName=sariftools.scans):
 
 [![Screenshot of Scans tab in sample build](./assets/screenshot-scans-tab.png)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/results?buildId=22505&view=sariftools.sarif-viewer-build-tab.sariftools.sarif-viewer-build-tab)
 

--- a/typescript-selenium-webdriver-sample/README.md
+++ b/typescript-selenium-webdriver-sample/README.md
@@ -47,7 +47,7 @@ The test pass/fail results display in the Tests tab of the build logs:
 
 [![Screenshot of Tests tab in sample build](./assets/screenshot-tests-tab.png)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/results?buildId=2228&view=ms.vss-test-web.build-test-results-tab)
 
-Detailed accessibliity scan information also appears in the Scans tab, courtesy of the [SARIF SAST Scans Tab extension](https://marketplace.visualstudio.com/items?itemName=sariftools.scans):
+Detailed accessibility scan information also appears in the Scans tab, courtesy of the [SARIF SAST Scans Tab extension](https://marketplace.visualstudio.com/items?itemName=sariftools.scans):
 
 [![Screenshot of Scans tab in sample build](./assets/screenshot-scans-tab.png)](https://dev.azure.com/accessibility-insights/axe-pipelines-samples/_build/results?buildId=2228&view=sariftools.sarif-viewer-build-tab.sariftools.sarif-viewer-build-tab)
 


### PR DESCRIPTION
#### Details

This fixes typos in two README files

##### Motivation

addresses issue #717 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] If this PR addresses an existing issue, it is linked: Fixes #717 
- [n/a] New sample content is commented at a similar verbosity as existing content
- [n/a] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` fail as expected
