### PR TITLE
Create a failing example pipeline for typescript-playwright-sample

### DIFF
--- a/typescript-playwright-sample/README.md
+++ b/typescript-playwright-sample/README.md
@@ -16,7 +16,7 @@ The individual files in the sample contain comments that explain the important p
 
 Some good places to start reading are:
 
-* [tests/index.spec.ts](./tests/index.spec.ts): Playwright test file that opens [src/index.html](./src/index.html) in a browser with Playwright and runs accessibility scans against it with `@axe-core/playwright`
+* [tests/passing-examples.spec.ts](./tests/passing-examples.spec.ts): Playwright test file that opens [src/index.html](./src/index.html) in a browser with Playwright and runs accessibility scans against it with `@axe-core/playwright`
 * [azure-pipelines.yml](./azure-pipelines.yml): Azure Pipelines config file that sets up our Continuous Integration and Pull Request builds
 * [playwright.config.ts](./playwright.config.ts): Playwright configuration file that enables test result reporting in Azure Pipelines (using the `junit` reporter)
 

--- a/typescript-playwright-sample/azure-pipelines.yml
+++ b/typescript-playwright-sample/azure-pipelines.yml
@@ -70,7 +70,11 @@ steps:
   #
   # If your project already uses npm instead of yarn, or if your project already runs "playwright test" directly here,
   # those are both fine.
-  - script: yarn test --browser=$(browser) # or "npm run test -- --browser=$(browser)"
+  #
+  # We use the EXTRA_PLAYWRIGHT_TEST_ARGUMENTS variable in the sample's CI/PR builds to separate our passing and failing
+  # example builds using Playwright Test's --project argument. You probably don't need EXTRA_PLAYWRIGHT_TEST_ARGUMENTS in
+  # a real project.
+  - script: yarn test --browser=$(browser) $(EXTRA_PLAYWRIGHT_TEST_ARGUMENTS) # or "npm run test -- --browser=$(browser)"
     displayName: yarn test
     workingDirectory: $(Build.SourcesDirectory)/typescript-playwright-sample
 

--- a/typescript-playwright-sample/playwright.config.ts
+++ b/typescript-playwright-sample/playwright.config.ts
@@ -1,25 +1,7 @@
 import { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
-    // You can use multiple projects to test against a variety of different
-    // browsers, devices, etc
-    //
-    // In this sample, we use one project to select just our passing example
-    // tests (to demonstrate what a passing CI build would look like) and a
-    // second project to run all of our example tests, including some that
-    // fail (to demonstrate what a failing CI build would look like)
-    projects: [
-        {
-            name: 'passing-example',
-            testMatch: '**/passing-examples.spec.ts',
-            retries: 3,
-        },
-        {
-            name: 'failing-example',
-            testMatch: '**/failing-examples.spec.ts'
-        }
-    ],
-
     // JUnit output is required to show results in Azure Pipelines' test view
     reporter: [['list'], ['junit', { outputFile: 'test-results/junit.xml' }]],
+    retries: 3,
 };
 export default config;

--- a/typescript-playwright-sample/playwright.config.ts
+++ b/typescript-playwright-sample/playwright.config.ts
@@ -1,7 +1,25 @@
 import { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
+    // You can use multiple projects to test against a variety of different
+    // browsers, devices, etc
+    //
+    // In this sample, we use one project to select just our passing example
+    // tests (to demonstrate what a passing CI build would look like) and a
+    // second project to run all of our example tests, including some that
+    // fail (to demonstrate what a failing CI build would look like)
+    projects: [
+        {
+            name: 'passing-example',
+            testMatch: '**/passing-examples.spec.ts',
+            retries: 3,
+        },
+        {
+            name: 'failing-example',
+            testMatch: '**/failing-examples.spec.ts'
+        }
+    ],
+
     // JUnit output is required to show results in Azure Pipelines' test view
     reporter: [['list'], ['junit', { outputFile: 'test-results/junit.xml' }]],
-    retries: 3,
 };
 export default config;

--- a/typescript-playwright-sample/tests/export-to-sarif.ts
+++ b/typescript-playwright-sample/tests/export-to-sarif.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as Axe from 'axe-core';
+import { convertAxeToSarif } from 'axe-sarif-converter';
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+
+// SARIF is a general-purpose log format for code analysis tools.
+//
+// Exporting axe results as .sarif files lets our Azure Pipelines build results page show a nice visualization
+// of any accessibility failures we find using the Sarif Results Viewer Tab extension
+// (https://marketplace.visualstudio.com/items?itemName=sariftools.sarif-viewer-build-tab)
+export async function exportAxeAsSarifTestResult(sarifFileName: string, axeResults: Axe.AxeResults, browserName: string): Promise<void> {
+    // We use the axe-sarif-converter package for the conversion step, then write the results
+    // to a file that we'll be publishing from a CI build step in azure-pipelines.yml
+    const sarifResults = convertAxeToSarif(axeResults);
+
+    // This directory should be .gitignore'd and should be published as a build artifact in azure-pipelines.yml
+    const testResultsDirectory = path.join(__dirname, '..', 'test-results', browserName);
+    await promisify(fs.mkdir)(testResultsDirectory, { recursive: true });
+
+    const sarifResultFile = path.join(testResultsDirectory, sarifFileName);
+    await promisify(fs.writeFile)(
+        sarifResultFile,
+        JSON.stringify(sarifResults, null, 2));
+
+    console.log(`Exported axe results to ${sarifResultFile}`);
+}

--- a/typescript-playwright-sample/tests/failing-examples.spec.ts
+++ b/typescript-playwright-sample/tests/failing-examples.spec.ts
@@ -3,7 +3,7 @@
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import * as path from 'path';
-import { exportAxeAsSarifTestResult } from './passing-examples.spec';
+import { exportAxeAsSarifTestResult } from './export-to-sarif';
 
 // This file contains test cases that intentionally fail; you can refer to this project's
 // "[failing example] typescript-playwright-sample" Pipeline to see what an accessibility

--- a/typescript-playwright-sample/tests/failing-examples.spec.ts
+++ b/typescript-playwright-sample/tests/failing-examples.spec.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { test, expect } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+import * as path from 'path';
+import { exportAxeAsSarifTestResult } from './passing-examples.spec';
+
+// This file contains test cases that intentionally fail; you can refer to this project's
+// "[failing example] typescript-playwright-sample" Pipeline to see what an accessibility
+// failure would look like in a real CI build.
+test.describe('[failing example] index.html', () => {
+
+    // This is the same setup as passing-examples.spec.ts; see its comments for details
+    test.beforeEach(async ({page}) => {
+        const pageUnderTest = 'file://' + path.join(__dirname, '..', 'src', 'index.html');
+        await page.goto(pageUnderTest);
+        await page.waitForSelector('h1');
+    });
+
+    // This test case scans an element which includes a few examples of accessibility violations.
+    test('accessibility of elements with issues', async ({ browserName, page }) => {
+        const accessibilityScanResults = await new AxeBuilder({ page })
+            .include('#example-accessibility-violations')
+            .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+            .analyze();
+            
+        await exportAxeAsSarifTestResult('index-except-examples.sarif', accessibilityScanResults, browserName);
+
+        expect(accessibilityScanResults.violations).toStrictEqual([]);
+    });
+});

--- a/typescript-playwright-sample/tests/passing-examples.spec.ts
+++ b/typescript-playwright-sample/tests/passing-examples.spec.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';
 
-test.describe('index.html', () => {
+test.describe('[passing examples] index.html', () => {
     test.beforeEach(async ({page}) => {
         // For simplicity, we're pointing our test browser directly to a static html file on disk.
         //
@@ -95,33 +95,33 @@ test.describe('index.html', () => {
             }
         ]);
     });
-
-    // You can make your "fingerprint" function as specific as you like. This one considers a violation to be
-    // "the same" if it corresponds the same Axe rule on the same set of elements.
-    const getViolationFingerprint = (violation: Axe.Result) => ({
-        rule: violation.id,
-        targets: violation.nodes.map(node => node.target),
-    });
-
-    // SARIF is a general-purpose log format for code analysis tools.
-    //
-    // Exporting axe results as .sarif files lets our Azure Pipelines build results page show a nice visualization
-    // of any accessibility failures we find using the Sarif Results Viewer Tab extension
-    // (https://marketplace.visualstudio.com/items?itemName=sariftools.sarif-viewer-build-tab)
-    async function exportAxeAsSarifTestResult(sarifFileName: string, axeResults: Axe.AxeResults, browserName: string): Promise<void> {
-        // We use the axe-sarif-converter package for the conversion step, then write the results
-        // to a file that we'll be publishing from a CI build step in azure-pipelines.yml
-        const sarifResults = convertAxeToSarif(axeResults);
-
-        // This directory should be .gitignore'd and should be published as a build artifact in azure-pipelines.yml
-        const testResultsDirectory = path.join(__dirname, '..', 'test-results', browserName);
-        await promisify(fs.mkdir)(testResultsDirectory, { recursive: true });
-
-        const sarifResultFile = path.join(testResultsDirectory, sarifFileName);
-        await promisify(fs.writeFile)(
-            sarifResultFile,
-            JSON.stringify(sarifResults, null, 2));
-
-        console.log(`Exported axe results to ${sarifResultFile}`);
-    }
 });
+
+// You can make your "fingerprint" function as specific as you like. This one considers a violation to be
+// "the same" if it corresponds the same Axe rule on the same set of elements.
+const getViolationFingerprint = (violation: Axe.Result) => ({
+    rule: violation.id,
+    targets: violation.nodes.map(node => node.target),
+});
+
+// SARIF is a general-purpose log format for code analysis tools.
+//
+// Exporting axe results as .sarif files lets our Azure Pipelines build results page show a nice visualization
+// of any accessibility failures we find using the Sarif Results Viewer Tab extension
+// (https://marketplace.visualstudio.com/items?itemName=sariftools.sarif-viewer-build-tab)
+export async function exportAxeAsSarifTestResult(sarifFileName: string, axeResults: Axe.AxeResults, browserName: string): Promise<void> {
+    // We use the axe-sarif-converter package for the conversion step, then write the results
+    // to a file that we'll be publishing from a CI build step in azure-pipelines.yml
+    const sarifResults = convertAxeToSarif(axeResults);
+
+    // This directory should be .gitignore'd and should be published as a build artifact in azure-pipelines.yml
+    const testResultsDirectory = path.join(__dirname, '..', 'test-results', browserName);
+    await promisify(fs.mkdir)(testResultsDirectory, { recursive: true });
+
+    const sarifResultFile = path.join(testResultsDirectory, sarifFileName);
+    await promisify(fs.writeFile)(
+        sarifResultFile,
+        JSON.stringify(sarifResults, null, 2));
+
+    console.log(`Exported axe results to ${sarifResultFile}`);
+}

--- a/typescript-playwright-sample/tests/passing-examples.spec.ts
+++ b/typescript-playwright-sample/tests/passing-examples.spec.ts
@@ -2,11 +2,9 @@
 // Licensed under the MIT License.
 import { test, expect } from '@playwright/test';
 import * as Axe from 'axe-core';
-import { convertAxeToSarif } from 'axe-sarif-converter';
 import AxeBuilder from '@axe-core/playwright';
-import * as fs from 'fs';
 import * as path from 'path';
-import { promisify } from 'util';
+import { exportAxeAsSarifTestResult } from './export-to-sarif';
 
 test.describe('[passing examples] index.html', () => {
     test.beforeEach(async ({page}) => {
@@ -103,25 +101,3 @@ const getViolationFingerprint = (violation: Axe.Result) => ({
     rule: violation.id,
     targets: violation.nodes.map(node => node.target),
 });
-
-// SARIF is a general-purpose log format for code analysis tools.
-//
-// Exporting axe results as .sarif files lets our Azure Pipelines build results page show a nice visualization
-// of any accessibility failures we find using the Sarif Results Viewer Tab extension
-// (https://marketplace.visualstudio.com/items?itemName=sariftools.sarif-viewer-build-tab)
-export async function exportAxeAsSarifTestResult(sarifFileName: string, axeResults: Axe.AxeResults, browserName: string): Promise<void> {
-    // We use the axe-sarif-converter package for the conversion step, then write the results
-    // to a file that we'll be publishing from a CI build step in azure-pipelines.yml
-    const sarifResults = convertAxeToSarif(axeResults);
-
-    // This directory should be .gitignore'd and should be published as a build artifact in azure-pipelines.yml
-    const testResultsDirectory = path.join(__dirname, '..', 'test-results', browserName);
-    await promisify(fs.mkdir)(testResultsDirectory, { recursive: true });
-
-    const sarifResultFile = path.join(testResultsDirectory, sarifFileName);
-    await promisify(fs.writeFile)(
-        sarifResultFile,
-        JSON.stringify(sarifResults, null, 2));
-
-    console.log(`Exported axe results to ${sarifResultFile}`);
-}


### PR DESCRIPTION
#### Details

This PR implements support for separate passing vs failing example pipelines for `typescript-playwright-sample`, similar to what we already have set up for `csharp-selenium-webdriver-sample`.

I've already set up the pipelines on the Azure DevOps side.

##### Motivation

Show off what a real failure might look like in practice

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [x] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` fail as expected
