### PR TITLE
chore(deps): update typescript samples to node 16

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
     # use for builds (ideally, latest LTS)
   - dependency-name: "@types/node"
     versions:
-    - ">=15.0.0"
+    - ">=17.0.0"
 - package-ecosystem: npm
   directory: "/typescript-playwright-sample"
   schedule:
@@ -31,4 +31,4 @@ updates:
     # use for builds (ideally, latest LTS)
   - dependency-name: "@types/node"
     versions:
-    - ">=15.0.0"
+    - ">=17.0.0"

--- a/typescript-playwright-sample/azure-pipelines.yml
+++ b/typescript-playwright-sample/azure-pipelines.yml
@@ -54,9 +54,9 @@ steps:
   # It is a good idea to test against a specific, known version of Node; this makes it easier for other users
   # to reproduce your build results.
   - task: NodeTool@0
-    displayName: install node 14.17.0
+    displayName: install node 16.15.0
     inputs:
-      versionSpec: "14.17.0"
+      versionSpec: "16.15.0"
 
   # This task installs dependencies specified in your package.json file.
   #

--- a/typescript-playwright-sample/package.json
+++ b/typescript-playwright-sample/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.4.2",
     "@playwright/test": "^1.22.1",
-    "@types/node": "^15.12.4",
+    "@types/node": "^16.11.36",
     "axe-sarif-converter": "^2.9.0",
     "playwright": "^1.22.1",
     "typescript": "^4.6.4"

--- a/typescript-playwright-sample/yarn.lock
+++ b/typescript-playwright-sample/yarn.lock
@@ -17,10 +17,10 @@
   dependencies:
     playwright-core "1.22.1"
 
-"@types/node@^15.12.4":
-  version "15.12.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
-  integrity sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==
+"@types/node@^16.11.36":
+  version "16.11.36"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.36.tgz#9ab9f8276987132ed2b225cace2218ba794fc751"
+  integrity sha512-FR5QJe+TaoZ2GsMHkjuwoNabr+UrJNRr2HNOo+r/7vhcuntM6Ee/pRPOnRhhL2XE9OOvX9VLEq+BcXl3VjNoWA==
 
 "@types/sarif@>=2.1.1 <=2.1.4":
   version "2.1.3"

--- a/typescript-selenium-webdriver-sample/azure-pipelines.yml
+++ b/typescript-selenium-webdriver-sample/azure-pipelines.yml
@@ -56,9 +56,9 @@ steps:
   # It is a good idea to test against a specific, known version of Node; this makes it easier for other users
   # to reproduce your build results.
   - task: NodeTool@0
-    displayName: install node 14.15.0
+    displayName: install node 16.15.0
     inputs:
-      versionSpec: "14.15.0"
+      versionSpec: "16.15.0"
 
   # This task installs dependencies specified in your package.json file.
   #

--- a/typescript-selenium-webdriver-sample/package.json
+++ b/typescript-selenium-webdriver-sample/package.json
@@ -6,7 +6,7 @@
     "devDependencies": {
         "@axe-core/webdriverjs": "^4.4.2",
         "@types/jest": "^27.5.0",
-        "@types/node": "^14.18.18",
+        "@types/node": "^16.11.36",
         "@types/selenium-webdriver": "^4.1.0",
         "axe-sarif-converter": "^2.9.0",
         "chromedriver": "^101.0.0",

--- a/typescript-selenium-webdriver-sample/yarn.lock
+++ b/typescript-selenium-webdriver-sample/yarn.lock
@@ -820,10 +820,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.6.1.tgz#32d43390d5c62c5b6ec486a9bc9c59544de39a08"
   integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
 
-"@types/node@^14.18.18":
-  version "14.18.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.18.tgz#5c9503030df484ccffcbb935ea9a9e1d6fad1a20"
-  integrity sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==
+"@types/node@^16.11.36":
+  version "16.11.36"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.36.tgz#9ab9f8276987132ed2b225cace2218ba794fc751"
+  integrity sha512-FR5QJe+TaoZ2GsMHkjuwoNabr+UrJNRr2HNOo+r/7vhcuntM6Ee/pRPOnRhhL2XE9OOvX9VLEq+BcXl3VjNoWA==
 
 "@types/prettier@^2.1.5":
   version "2.2.3"


### PR DESCRIPTION
#### Details

This PR updates our Typescript samples to use the current LTS version of node (16.15.0). It also updates node typings (and our dependabot policy for updating them) accordingly.

##### Motivation

Keep dependencies up to date

##### Context

n/a

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` fail as expected
