### PR TITLE
fix: swap typescript assertions from toStrictEqual to toEqual

### DIFF
--- a/typescript-playwright-sample/tests/failing-examples.spec.ts
+++ b/typescript-playwright-sample/tests/failing-examples.spec.ts
@@ -26,6 +26,6 @@ test.describe('[failing example] index.html', () => {
             
         await exportAxeAsSarifTestResult('index-except-examples.sarif', accessibilityScanResults, browserName);
 
-        expect(accessibilityScanResults.violations).toStrictEqual([]);
+        expect(accessibilityScanResults.violations).toEqual([]);
     });
 });

--- a/typescript-playwright-sample/tests/passing-examples.spec.ts
+++ b/typescript-playwright-sample/tests/passing-examples.spec.ts
@@ -40,7 +40,7 @@ test.describe('[passing examples] index.html', () => {
 
         await exportAxeAsSarifTestResult('index-h1-element.sarif', accessibilityScanResults, browserName);
 
-        expect(accessibilityScanResults.violations).toStrictEqual([]);
+        expect(accessibilityScanResults.violations).toEqual([]);
     });
 
     // If you want to run a scan of a page but need to exclude an element with known issues (eg, a third-party
@@ -54,7 +54,7 @@ test.describe('[passing examples] index.html', () => {
             
         await exportAxeAsSarifTestResult('index-except-examples.sarif', accessibilityScanResults, browserName);
 
-        expect(accessibilityScanResults.violations).toStrictEqual([]);
+        expect(accessibilityScanResults.violations).toEqual([]);
     });
 
     // If you want to more precisely baseline a particular set of known issues, you can extract a "fingerprint"

--- a/typescript-selenium-webdriver-sample/tests/index.test.ts
+++ b/typescript-selenium-webdriver-sample/tests/index.test.ts
@@ -63,7 +63,7 @@ describe('index.html', () => {
 
         await exportAxeAsSarifTestResult('index-h1-element.sarif', accessibilityScanResults);
 
-        expect(accessibilityScanResults.violations).toStrictEqual([]);
+        expect(accessibilityScanResults.violations).toEqual([]);
     }, TEST_TIMEOUT_MS);
 
     // If you want to run a scan of a page but need to exclude an element with known issues (eg, a third-party
@@ -77,7 +77,7 @@ describe('index.html', () => {
 
         await exportAxeAsSarifTestResult('index-except-examples.sarif', accessibilityScanResults);
 
-        expect(accessibilityScanResults.violations).toStrictEqual([]);
+        expect(accessibilityScanResults.violations).toEqual([]);
     }, TEST_TIMEOUT_MS);
 
     // If you want to more precisely baseline a particular set of known issues, one option is to use Jest


### PR DESCRIPTION
#### Details

During last Friday's office hours, one user tried following our samples in a project which was using a test library that provided an `expect` implementation whose `toStrictEqual` assertion worked slightly differently from Jest/`@playwright/test`'s. Our samples use assertions like `expect(axeResults.violations).toStrictEqual([]);` - this works in our samples because that expectation is testing for `===` equality of list members, but in this particular user's case, their test library used something more like `testSubject === []`, which failed with a confusing error (since the two empty lists in question were string-equal and didn't have a diff).

In that user's case, switching to `.toEqual` was the solution. `.toEqual` is an equally valid test assertion for the our Jest/`@playwright/test` usage, so I'm swapping the samples to use it to avoid other users falling into this confusion.

##### Motivation

Avoid user confusion

##### Context

n/a

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] If this PR addresses an existing issue, it is linked: Fixes #0000
- [ ] New sample content is commented at a similar verbosity as existing content
- [ ] All updated/modified sample code builds and runs in at least one PR/CI build
- [ ] PR checks for builds named `[failing example] ...` fail as expected
