### PR TITLE
chore: Update mac environment from 10.15 to 11

### DIFF
--- a/typescript-playwright-sample/azure-pipelines.yml
+++ b/typescript-playwright-sample/azure-pipelines.yml
@@ -42,7 +42,7 @@ strategy:
       imageName: ubuntu-20.04
       browser: firefox
     mac-webkit:
-      imageName: macOS-10.15
+      imageName: macOS-11
       browser: webkit
 
 pool:


### PR DESCRIPTION
#### Details

MacOS 10.15 is being phased out as a virtual environment. We're getting the following warnings in our builds:
```
The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead. For more details see https://github.com/actions/virtual-environments/issues/5583
```

This PR simply changes all instances of `macOS-10.15` to `macOS-11`.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->
We could use `macOS-latest` to avoid having to touch these files in the future, but deprecations are infrequent and having an explicit version makes it easier to identify cases where tests potentially fail after changing OS versions.

We could use `macOS-12`, but that would leave downlevel clients with no testing in our pipeline. Since most of our internal testing will be on macOS 12 (required for security reasons), using `macOS-11` is a cheap and easy way to get version coverage.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` fail as expected
