### PR TITLE
chore: update combine-dependabot-PRs workflow

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   combine-prs:
+    if: github.event_name != 'schedule' || github.repository_owner == 'microsoft'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.3


### PR DESCRIPTION
#### Details

Update combine-dependabot-prs workflow so that the scheduled job doesn't run on forks. It can still be run manually.

##### Motivation

Avoid auto-generating PRs in forks

##### Context

The combine-dependabot-prs workflow was added in #1021

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] New sample content is commented at a similar verbosity as existing content
- [n/a] All updated/modified sample code builds and runs in at least one PR/CI build
- [n/a] PR checks for builds named `[failing example] ...` fail as expected
