### PR TITLE
chore: Enable write permissions for combine-dependabot-prs

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -7,6 +7,10 @@ on:
     - cron: '0 13 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   combine-prs:
     if: github.event_name != 'schedule' || github.repository_owner == 'microsoft'


### PR DESCRIPTION
#### Details

Enable write permissions for combine-dependabot-prs

##### Motivation

Allow the combine-dependabot-prs workflow to work if we change action permissions to read only

##### Context

Tested in [accessibility-insights-web](https://github.com/microsoft/accessibility-insights-web/actions/runs/3499742576)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] New sample content is commented at a similar verbosity as existing content
- [n/a] All updated/modified sample code builds and runs in at least one PR/CI build
- [ ] PR checks for builds named `[failing example] ...` fail as expected
