### PR TITLE
chore: Special case dependabot to pass tests

### DIFF
--- a/csharp-selenium-webdriver-sample/SamplePageTests.cs
+++ b/csharp-selenium-webdriver-sample/SamplePageTests.cs
@@ -52,7 +52,17 @@ namespace CSharpSeleniumWebdriverSample
             // full descriptions of accessibility issues, including links to detailed guidance at https://dequeuniversity.com
             // and CSS selector paths that exactly identify the element on the page with the issue.
             axeResult.Error.Should().BeNull();
-            axeResult.Violations.Should().BeEmpty();
+
+            // We special case dependabot PR's to break the build only if the expected violations are *not* found.
+            // You can remove this if you don't want or need this behavior.
+            if (IsDependabotTheSourceVersionAuthor()) 
+            {
+                axeResult.Violations.Should().NotBeEmpty();
+            }
+            else
+            {
+                axeResult.Violations.Should().BeEmpty();
+            }
         }
 
         // This test case shows 2 options for scanning specific elements within a page, rather than an entire page.
@@ -177,6 +187,14 @@ namespace CSharpSeleniumWebdriverSample
         }
 
         private static IWebDriver _webDriver;
+
+        #endregion
+
+        #region Helper methods
+
+        private bool IsDependabotTheSourceVersionAuthor() {
+            return Environment.GetEnvironmentVariable("BUILD_SOURCEVERSIONAUTHOR") == "dependabot[bot]";
+        }
 
         #endregion
     }

--- a/typescript-playwright-sample/tests/failing-examples.spec.ts
+++ b/typescript-playwright-sample/tests/failing-examples.spec.ts
@@ -26,6 +26,16 @@ test.describe('[failing example] index.html', () => {
             
         await exportAxeAsSarifTestResult('index-except-examples.sarif', accessibilityScanResults, browserName);
 
-        expect(accessibilityScanResults.violations).toEqual([]);
+            // We special case dependabot PR's to break the build only if the expected violations are *not* found.
+        // You can remove this if you don't want or need this behavior.
+        if (isDependabotTheSourceVersionAuthor()) {
+            expect(accessibilityScanResults.violations).not.toEqual([]);
+        } else {
+            expect(accessibilityScanResults.violations).toEqual([]);
+        }
     });
+
+    function isDependabotTheSourceVersionAuthor(): boolean {
+        return process.env['BUILD_SOURCEVERSIONAUTHOR'] === 'dependabot[bot]';
+    }
 });


### PR DESCRIPTION
#### Details

PR's of this repo contain 2 checks that intentionally fail to demonstrate what customers would do. These also fail in dependabot PR's, so we need to take time to ensure not only that they failed, but that they failed in the expected way. This only takes a minute or two for each PR, but when we get 20 or more dependabot PR's per month, it starts to add up. This PR leaves the failing behavior intact when running locally or for non-dependabot PR's, but takes advantage of an ADO pipeline variable to recognize a PR from dependabot and fail the check only if an unexpected error occurs.

##### Motivation

Simplify dependabot PR handling

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [ ] If this PR addresses an existing issue, it is linked: Fixes #0000
- [ ] New sample content is commented at a similar verbosity as existing content
- [ ] All updated/modified sample code builds and runs in at least one PR/CI build
- [ ] PR checks for builds named `[failing example] ...` fail as expected
