### PR TITLE
chore: Make "failing" pipelines pass in PR builds but fail in CI builds

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,4 +18,4 @@
 - [ ] If this PR addresses an existing issue, it is linked: Fixes #0000
 - [ ] New sample content is commented at a similar verbosity as existing content
 - [ ] All updated/modified sample code builds and runs in at least one PR/CI build
-- [ ] PR checks for builds named `[failing example] ...` fail as expected
+- [ ] PR checks for builds named `[failing example] ...` pass in the PR build, then confirm they fail in the CI build

--- a/csharp-selenium-webdriver-sample/SamplePageTests.cs
+++ b/csharp-selenium-webdriver-sample/SamplePageTests.cs
@@ -53,9 +53,11 @@ namespace CSharpSeleniumWebdriverSample
             // and CSS selector paths that exactly identify the element on the page with the issue.
             axeResult.Error.Should().BeNull();
 
-            // We special case dependabot PR's to break the build only if the expected violations are *not* found.
-            // You can remove this if you don't want or need this behavior.
-            if (IsDependabotTheSourceVersionAuthor()) 
+            // Our PR builds do not change the presence or absence of accessibility issues, so we special case
+            // our PR build tests to expect the errors. This is not recommended for most projects, but since the
+            // check takes effect only if the ACCESSIBILITY_ERRORS_ARE_EXPECTED_IN_PR_BUILD variable is set to
+            // true within the pipeline, you may safely copy this code and the special case will be ignored.
+            if (AccessibilityErrorsAreExpectedInThisBuild()) 
             {
                 axeResult.Violations.Should().NotBeEmpty();
             }
@@ -192,8 +194,10 @@ namespace CSharpSeleniumWebdriverSample
 
         #region Helper methods
 
-        private bool IsDependabotTheSourceVersionAuthor() {
-            return Environment.GetEnvironmentVariable("BUILD_SOURCEVERSIONAUTHOR") == "dependabot[bot]";
+        private bool AccessibilityErrorsAreExpectedInThisBuild() {
+            return
+                Environment.GetEnvironmentVariable("ACCESSIBILITY_ERRORS_ARE_EXPECTED_IN_PR_BUILD") == "true" &&
+                Environment.GetEnvironmentVariable("BUILD_SOURCEBRANCH") != "refs/heads/main";
         }
 
         #endregion

--- a/typescript-playwright-sample/tests/failing-examples.spec.ts
+++ b/typescript-playwright-sample/tests/failing-examples.spec.ts
@@ -26,16 +26,19 @@ test.describe('[failing example] index.html', () => {
             
         await exportAxeAsSarifTestResult('index-except-examples.sarif', accessibilityScanResults, browserName);
 
-            // We special case dependabot PR's to break the build only if the expected violations are *not* found.
-        // You can remove this if you don't want or need this behavior.
-        if (isDependabotTheSourceVersionAuthor()) {
+        // Our PR builds do not change the presence or absence of accessibility issues, so we special case
+        // our PR build tests to expect the errors. This is not recommended for most projects, but since the
+        // check takes effect only if the ACCESSIBILITY_ERRORS_ARE_EXPECTED_IN_PR_BUILD variable is set to
+        // true within the pipeline, you may safely copy this code and the special case will be ignored.
+        if (AccessibilityErrorsAreExpectedInThisBuild()) {
             expect(accessibilityScanResults.violations).not.toEqual([]);
         } else {
             expect(accessibilityScanResults.violations).toEqual([]);
         }
     });
 
-    function isDependabotTheSourceVersionAuthor(): boolean {
-        return process.env['BUILD_SOURCEVERSIONAUTHOR'] === 'dependabot[bot]';
+    function AccessibilityErrorsAreExpectedInThisBuild(): boolean {
+        return process.env["ACCESSIBILITY_ERRORS_ARE_EXPECTED_IN_PR_BUILD"] === "true" &&
+            process.env["BUILD_SOURCEBRANCH"] !== "refs/heads/main";
     }
 });


### PR DESCRIPTION
#### Details

When first written, we had 2 pipelines that were "failing examples" to show customers what failures look like. However, these pipelines created a lot of friction for dependabot changes, so we added #1237 to streamline the PR approval process. Unfortunately, the user-facing docs use the pipeline as a demo of the failing builds, so this caused a documentaion problem.

One option would be to split the PR and the CLI into 2 distinct pipelines, but that introduces some organizational friction that we'd prefer to avoid. The alternative is to use the same pipeline for both the PR and CI builds, but make them behave differently--tests in PR builds all pass (to streamline the review), while tests in CI builds (i.e., built from the main branch) fail (to provide the doc examples).

The `ACCESSIBILITY_ERRORS_ARE_EXPECTED_IN_PR_BUILD` variable has already been set in the 2 failing pipelines, so the unit tests for this PR should come up all green.

##### Motivation

Make the docs useful while still streamlining the PR process

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` pass PR's, then confirm they fail in the CI build
