### PR TITLE
feat: Update to axe-core 4.7.2

### DIFF
--- a/typescript-playwright-sample/package.json
+++ b/typescript-playwright-sample/package.json
@@ -4,7 +4,7 @@
   "description": "Sample project that demonstrates accessibility testing with TypeScript, Playwright, @axe-core/playwright, SARIF, and Azure Pipelines.",
   "private": true,
   "devDependencies": {
-    "@axe-core/playwright": "^4.7.1",
+    "@axe-core/playwright": "^4.7.2",
     "@playwright/test": "^1.36.2",
     "@types/node": "^16.18.39",
     "axe-sarif-converter": "^2.10.1",

--- a/typescript-playwright-sample/yarn.lock
+++ b/typescript-playwright-sample/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@axe-core/playwright@^4.7.1":
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.7.1.tgz#e0ed94013da9bdd9d221483c5f7c9ff2560e53de"
-  integrity sha512-09UDwLChlGiqw9004QJib6Maesy99EOZ9zsLfhBYAt2s5UwufabnD+MoTAmwe+PCv2Jex9k1taeUhebDwIJKqw==
+"@axe-core/playwright@^4.7.2":
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/@axe-core/playwright/-/playwright-4.7.3.tgz#aa9b9e563c2c2c5024ff777da6c4f2e5f93dd8f4"
+  integrity sha512-v2PRgAyGvop7bamrTpNJtc5b1R7giAPnMzZXrS/VDZBCY5+uwVYtCNgDvBsqp5P1QMZxUMoBN+CERJUTMjFN0A==
   dependencies:
     axe-core "^4.7.0"
 


### PR DESCRIPTION
#### Details

Update to latest version (4.7.2) of `axe-core` package. 

##### Motivation

Part of axe-core update feature

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->
The `axe-core/webdriver.js` package has been at version 4.7.3 for some time. If it's important to keep these in sync, we should consider excluding this package from dependabot updates

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [x] If this PR addresses an existing issue, it is linked: Addresses ADO [#2087698](https://mseng.visualstudio.com/1ES/_workitems/edit/2087698)
- [n/a] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` pass in the PR build, then confirm they fail in the CI build
