### PR TITLE
feat(oncall-vendor-transition): Increase Dependabot limit and move scheduled runs to 08:30 UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,12 @@ updates:
   directory: "/csharp-selenium-webdriver-sample"
   schedule:
     interval: daily
-    time: "11:00"
-    timezone: "America/Los_Angeles" # Pacific Time
+    time: "08:30"  # UTC
 - package-ecosystem: npm
   directory: "/typescript-selenium-webdriver-sample"
   schedule:
     interval: daily
-    time: "11:00"
-    timezone: "America/Los_Angeles" # Pacific Time
+    time: "08:30"  # UTC
   versioning-strategy: increase
   ignore:
     # Major version of @types/node is pinned to match the version of node we
@@ -23,8 +21,7 @@ updates:
   directory: "/typescript-playwright-sample"
   schedule:
     interval: daily
-    time: "11:00"
-    timezone: "America/Los_Angeles" # Pacific Time
+    time: "08:30"  # UTC
   versioning-strategy: increase
   ignore:
     # Major version of @types/node is pinned to match the version of node we

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
   schedule:
     interval: daily
     time: "08:30"  # UTC
+  open-pull-requests-limit: 10  # Default value of 5 has been problematic
 - package-ecosystem: npm
   directory: "/typescript-selenium-webdriver-sample"
   schedule:
@@ -17,6 +18,7 @@ updates:
   - dependency-name: "@types/node"
     versions:
     - ">=17.0.0"
+  open-pull-requests-limit: 10  # Default value of 5 has been problematic
 - package-ecosystem: npm
   directory: "/typescript-playwright-sample"
   schedule:
@@ -29,3 +31,4 @@ updates:
   - dependency-name: "@types/node"
     versions:
     - ">=17.0.0"
+  open-pull-requests-limit: 10  # Default value of 5 has been problematic


### PR DESCRIPTION
#### Details
* Dependabot for our repos is scheduled to run at fairly different times that are inconvenient for some geographies. This PR moves this repo's dependabot time to 08:30 UTC (14:00 IST, 01:30 PDT, 00:30 PST).
* Web-based projects have many dependencies, and a low Dependabot PR limit causes us to need to run Dependabot manually multiple times to update all dependencies. This PR increases the limit for all dependency receptacles to 10 as consistent with other repos.

##### Motivation
Part of [Feature 2083093](https://mseng.visualstudio.com/1ES/_queries/edit/2083093) (internal access required to view).

#### Pull request checklist
- [n/a] If this PR addresses an existing issue, it is linked: Fixes #0000
- [n/a] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` pass in the PR build, then confirm they fail in the CI build
