### PR TITLE
chore: Update to Node 20.x (current LTS version)

### DIFF
--- a/typescript-playwright-sample/azure-pipelines.yml
+++ b/typescript-playwright-sample/azure-pipelines.yml
@@ -54,9 +54,9 @@ steps:
   # It is a good idea to test against a specific, known version of Node; this makes it easier for other users
   # to reproduce your build results.
   - task: NodeTool@0
-    displayName: install node 16.15.0
+    displayName: install node 20.8.1
     inputs:
-      versionSpec: "16.15.0"
+      versionSpec: "20.8.1"
 
   # This task installs dependencies specified in your package.json file.
   #

--- a/typescript-selenium-webdriver-sample/azure-pipelines.yml
+++ b/typescript-selenium-webdriver-sample/azure-pipelines.yml
@@ -56,9 +56,9 @@ steps:
   # It is a good idea to test against a specific, known version of Node; this makes it easier for other users
   # to reproduce your build results.
   - task: NodeTool@0
-    displayName: install node 16.15.0
+    displayName: install node 20.8.1
     inputs:
-      versionSpec: "16.15.0"
+      versionSpec: "20.8.1"
 
   # This task installs dependencies specified in your package.json file.
   #


### PR DESCRIPTION
#### Details

Node 16 is no longer in support. This moves us up to the currently active version of Node

##### Motivation

Get on a current version, unblock packages that no longer support Node 16

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] If this PR addresses an existing issue, it is linked
- [x] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` pass in the PR build, then confirm they fail in the CI build
