### PR TITLE
chore: Use current .NET tools

### DIFF
--- a/csharp-selenium-webdriver-sample/CSharpSeleniumWebdriverSample.csproj
+++ b/csharp-selenium-webdriver-sample/CSharpSeleniumWebdriverSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <ProjectGuid>{E6205F43-94B0-462C-AA5B-AE816794E95A}</ProjectGuid>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AssemblyTitle>CSharpSeleniumWebdriverSample</AssemblyTitle>
     <Product>CSharpSeleniumWebdriverSample</Product>
   </PropertyGroup>

--- a/csharp-selenium-webdriver-sample/azure-pipelines.yml
+++ b/csharp-selenium-webdriver-sample/azure-pipelines.yml
@@ -52,12 +52,12 @@ variables:
 steps:
   # This task makes sure .NET Core SDK is installed on the build agent.
   #
-  # It is a good idea to test against a specific, known version of .NET Core SDK; this makes it easier for other users
+  # It is a good idea to test against a specific, known version of .NET SDK; this makes it easier for other users
   # to reproduce your build results.
-  - task: DotNetCoreInstaller@1
-    displayName: install .NET Core SDK 3.1.201
+  - task: UseDotNet@2
+    displayName: install .NET 6.0.415
     inputs:
-      version: '3.1.201'
+      version: '6.0.415'
 
   - task: DotNetCoreCLI@2
     displayName: dotnet restore


### PR DESCRIPTION
#### Details

.NET Core 3.1 reached its end of life in December 2022. The current LTS .NET version is 6.0, with the most recent SDK version ([reference](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)) being 6.0.415. This PR updates the tools and project accordingly. 

The [DotNetCoreInstaller@1](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/dotnet-core-installer-v1) has similarly been deprectaed. Its replacement is the [UseDotNet@2](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/use-dotnet-v2) task.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] If this PR addresses an existing issue, it is linked: 
- [x] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` pass in the PR build, then confirm they fail in the CI build
