### PR TITLE
fix: Enable local selenium tests

### DIFF
--- a/typescript-selenium-webdriver-sample/tests/index.test.ts
+++ b/typescript-selenium-webdriver-sample/tests/index.test.ts
@@ -8,6 +8,7 @@ import * as path from 'path';
 import { By, ThenableWebDriver, until } from 'selenium-webdriver';
 import { promisify } from 'util';
 import { createWebdriverFromEnvironmentVariableSettings } from './webdriver-factory';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
 
 // The default timeout for tests/fixtures (5 seconds) is not always enough to start/quit/navigate a browser instance.
 const TEST_TIMEOUT_MS = 30000;

--- a/typescript-selenium-webdriver-sample/tsconfig.json
+++ b/typescript-selenium-webdriver-sample/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "outDir": "./test-results/"
+    },
+    "exclude": [
+        "node_modules"
+    ]
+}


### PR DESCRIPTION
#### Details

When #1350 moved to Node 20, local tests in the `typescript-selenium-webdriver-sample` project broke because the tests could no longer find the types from `jest`. Importing them explicitly into the test file fixed that problem, but then the system was unhappy because it couldn't find the `outputDir`, so I added a `tsconfig.json` file.

Confirmed that the tests succeed locally with the following commands
```
yarn test
yarn test:chrome
yarn test:firefox
```

##### Motivation

Broken samples are bad

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] If this PR addresses an existing issue, it is linked:
- [x] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` pass in the PR build, then confirm they fail in the CI build
