### PR TITLE
chore: Update @types/node to match current Node version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,5 +30,5 @@ updates:
     # use for builds (ideally, latest LTS)
   - dependency-name: "@types/node"
     versions:
-    - ">=17.0.0"
+    - ">=21.0.0"
   open-pull-requests-limit: 10  # Default value of 5 has been problematic

--- a/typescript-playwright-sample/package.json
+++ b/typescript-playwright-sample/package.json
@@ -6,7 +6,7 @@
   "devDependencies": {
     "@axe-core/playwright": "^4.8.1",
     "@playwright/test": "^1.39.0",
-    "@types/node": "^16.18.60",
+    "@types/node": "^20.8.10",
     "axe-sarif-converter": "^2.11.0",
     "typescript": "^5.2.2"
   },

--- a/typescript-playwright-sample/yarn.lock
+++ b/typescript-playwright-sample/yarn.lock
@@ -39,10 +39,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
   integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
 
-"@types/node@^16.18.60":
-  version "16.18.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.60.tgz#0b0f4316906f1bd0e03b640363f67bd4e86958bd"
-  integrity sha512-ZUGPWx5vKfN+G2/yN7pcSNLkIkXEvlwNaJEd4e0ppX7W2S8XAkdc/37hM4OUNJB9sa0p12AOvGvxL4JCPiz9DA==
+"@types/node@^20.8.10":
+  version "20.8.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.10.tgz#a5448b895c753ae929c26ce85cab557c6d4a365e"
+  integrity sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/sarif@>=2.1.1 <=2.1.4":
   version "2.1.3"
@@ -535,6 +537,11 @@ unbzip2-stream@1.4.3:
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/typescript-selenium-webdriver-sample/package.json
+++ b/typescript-selenium-webdriver-sample/package.json
@@ -6,7 +6,7 @@
     "devDependencies": {
         "@axe-core/webdriverjs": "^4.8.1",
         "@types/jest": "^27.5.0",
-        "@types/node": "^16.18.60",
+        "@types/node": "^20.8.10",
         "@types/selenium-webdriver": "^4.1.19",
         "axe-sarif-converter": "^2.11.0",
         "chromedriver": "^119.0.0",

--- a/typescript-selenium-webdriver-sample/yarn.lock
+++ b/typescript-selenium-webdriver-sample/yarn.lock
@@ -844,10 +844,17 @@
     jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/node@*", "@types/node@^16.18.60":
+"@types/node@*":
   version "16.18.60"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.60.tgz#0b0f4316906f1bd0e03b640363f67bd4e86958bd"
   integrity sha512-ZUGPWx5vKfN+G2/yN7pcSNLkIkXEvlwNaJEd4e0ppX7W2S8XAkdc/37hM4OUNJB9sa0p12AOvGvxL4JCPiz9DA==
+
+"@types/node@^20.8.10":
+  version "20.8.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.8.10.tgz#a5448b895c753ae929c26ce85cab557c6d4a365e"
+  integrity sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/prettier@^2.1.5":
   version "2.2.3"
@@ -3473,6 +3480,11 @@ unbzip2-stream@1.4.3:
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
#### Details

#1350 updated to Node 20.x, but dependabot is still locked on 16.x. This PR updates to 20.x and allows dependabot to create PR's for updates as they become available.

##### Motivation

@types/node should be on the same major version as node

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [n/a] If this PR addresses an existing issue, it is linked: 
- [x] New sample content is commented at a similar verbosity as existing content
- [x] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` pass in the PR build, then confirm they fail in the CI build
