### PR TITLE
fix: Added skip setting for 1ES PT tag in ADO pipeline

### DIFF
--- a/csharp-selenium-webdriver-sample/azure-pipelines.yml
+++ b/csharp-selenium-webdriver-sample/azure-pipelines.yml
@@ -54,6 +54,8 @@ resources:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
     pool:
       name: $(a11yInsightsPool)  # Name of your hosted pool
       image: windows-2022-secure  # Name of the image in your pool. If not specified, first image of the pool is used

--- a/typescript-playwright-sample/azure-pipelines.yml
+++ b/typescript-playwright-sample/azure-pipelines.yml
@@ -60,6 +60,8 @@ resources:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
     # Update the pool with your team's 1ES hosted pool.
     pool:
       name: $(a11yInsightsPool) # Name of your hosted pool

--- a/typescript-selenium-webdriver-sample/azure-pipelines.yml
+++ b/typescript-selenium-webdriver-sample/azure-pipelines.yml
@@ -56,6 +56,9 @@ resources:
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
+      
     pool:
       name: $(a11yInsightsPool)  # Name of your hosted pool
       image: windows-2022-secure  # Name of the image in your pool. If not specified, first image of the pool is used


### PR DESCRIPTION
#### Details

1ES PT adds tags to pipeline runs using the access token provided by ADO. In the case of pipeline runs against forked repos of a GitHub repo, the access token does not have Edit build quality permissions and hence cannot add tags. To unblock those pipelines, skipped tagging by using the option SkipBuildTagsForGitHubPullRequests.

Verified that the only change in the pipeline run is that it do not add "1ES.PT.Unofficial" tag on the Run. In place of that it adds below warning message.

##[warning]1ES PT Warning: Skipping build tags as this build is a pull request form GitHub which does not have permissions to add tags.

##### Motivation

<!-- This can be as simple as "addresses issue #123" -->

##### Context

<!-- Are there any parts that you've intentionally left out-of-scope for a later PR to handle? -->

<!-- Were there any alternative approaches you considered? What tradeoffs did you consider? -->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->

- [na] If this PR addresses an existing issue, it is linked: Fixes #0000
- [na] New sample content is commented at a similar verbosity as existing content
- [na] All updated/modified sample code builds and runs in at least one PR/CI build
- [x] PR checks for builds named `[failing example] ...` pass in the PR build, then confirm they fail in the CI build
